### PR TITLE
Did word2vec embedding

### DIFF
--- a/EDA_and_preprocessing/word2vec-wine-review.ipynb
+++ b/EDA_and_preprocessing/word2vec-wine-review.ipynb
@@ -1997,7 +1997,7 @@
     "tags": []
    },
    "source": [
-    "### Since we used sentences as documents in minority classes and further lemmatize these sentences in our tokenizer function, some documents may have no sentence in them after tokenizing. We will drop such observations and thier corresponding labels"
+    "### Since we used sentences as documents in minority classes and further lemmatize these sentences in our tokenizer function, some documents may have no sentence in them after tokenizing. We will drop such observations and thier corresponding labels."
    ]
   },
   {
@@ -2530,7 +2530,7 @@
     "tags": []
    },
    "source": [
-    "### let's see how the combination of ````description```` and ````not_vintage```` is like"
+    "### let's see how the combination of ````description```` and ````not_vintage```` is like."
    ]
   },
   {


### PR DESCRIPTION
Word2Vec embedding was used as a preprocessing strategy in word2vec-wine-review.ipynb notebook

find the notebook [here](https://github.com/Jolomi-Tosanwumi/stage-f-06-wine-tasting/blob/master/EDA_and_preprocessing/word2vec-wine-review.ipynb)