### PR TITLE
Read in the zipped dataset using only pandas

### DIFF
--- a/pipeline/cnn-pipeline-model.ipynb
+++ b/pipeline/cnn-pipeline-model.ipynb
@@ -7,10 +7,10 @@
     "_uuid": "d629ff2d2480ee46fbb7e2d37f6b5fab8052498a",
     "collapsed": true,
     "papermill": {
-     "duration": 0.044643,
-     "end_time": "2020-11-10T04:08:30.856510",
+     "duration": 0.039949,
+     "end_time": "2020-11-11T00:23:20.015405",
      "exception": false,
-     "start_time": "2020-11-10T04:08:30.811867",
+     "start_time": "2020-11-11T00:23:19.975456",
      "status": "completed"
     },
     "tags": []
@@ -24,16 +24,16 @@
    "execution_count": 1,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:08:30.952328Z",
-     "iopub.status.busy": "2020-11-10T04:08:30.951493Z",
-     "iopub.status.idle": "2020-11-10T04:08:32.044974Z",
-     "shell.execute_reply": "2020-11-10T04:08:32.044368Z"
+     "iopub.execute_input": "2020-11-11T00:23:20.098576Z",
+     "iopub.status.busy": "2020-11-11T00:23:20.097880Z",
+     "iopub.status.idle": "2020-11-11T00:23:20.918089Z",
+     "shell.execute_reply": "2020-11-11T00:23:20.916956Z"
     },
     "papermill": {
-     "duration": 1.144465,
-     "end_time": "2020-11-10T04:08:32.045093",
+     "duration": 0.86509,
+     "end_time": "2020-11-11T00:23:20.918219",
      "exception": false,
-     "start_time": "2020-11-10T04:08:30.900628",
+     "start_time": "2020-11-11T00:23:20.053129",
      "status": "completed"
     },
     "tags": []
@@ -46,10 +46,6 @@
     "import matplotlib.pyplot as plt\n",
     "import seaborn as sns\n",
     "\n",
-    "import requests\n",
-    "import zipfile\n",
-    "import io\n",
-    "\n",
     "import warnings\n",
     "warnings.filterwarnings('ignore')\n",
     "\n",
@@ -60,10 +56,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.046496,
-     "end_time": "2020-11-10T04:08:32.133967",
+     "duration": 0.038562,
+     "end_time": "2020-11-11T00:23:21.000403",
      "exception": false,
-     "start_time": "2020-11-10T04:08:32.087471",
+     "start_time": "2020-11-11T00:23:20.961841",
      "status": "completed"
     },
     "tags": []
@@ -77,16 +73,16 @@
    "execution_count": 2,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:08:32.222904Z",
-     "iopub.status.busy": "2020-11-10T04:08:32.221995Z",
-     "iopub.status.idle": "2020-11-10T04:08:32.224898Z",
-     "shell.execute_reply": "2020-11-10T04:08:32.224385Z"
+     "iopub.execute_input": "2020-11-11T00:23:21.080193Z",
+     "iopub.status.busy": "2020-11-11T00:23:21.079405Z",
+     "iopub.status.idle": "2020-11-11T00:23:21.081948Z",
+     "shell.execute_reply": "2020-11-11T00:23:21.082425Z"
     },
     "papermill": {
-     "duration": 0.049868,
-     "end_time": "2020-11-10T04:08:32.225000",
+     "duration": 0.044267,
+     "end_time": "2020-11-11T00:23:21.082544",
      "exception": false,
-     "start_time": "2020-11-10T04:08:32.175132",
+     "start_time": "2020-11-11T00:23:21.038277",
      "status": "completed"
     },
     "tags": []
@@ -102,27 +98,24 @@
    "execution_count": 3,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:08:32.315331Z",
-     "iopub.status.busy": "2020-11-10T04:08:32.314673Z",
-     "iopub.status.idle": "2020-11-10T04:08:36.784805Z",
-     "shell.execute_reply": "2020-11-10T04:08:36.783866Z"
+     "iopub.execute_input": "2020-11-11T00:23:21.171674Z",
+     "iopub.status.busy": "2020-11-11T00:23:21.171024Z",
+     "iopub.status.idle": "2020-11-11T00:23:23.161666Z",
+     "shell.execute_reply": "2020-11-11T00:23:23.160584Z"
     },
     "papermill": {
-     "duration": 4.517526,
-     "end_time": "2020-11-10T04:08:36.784930",
+     "duration": 2.041484,
+     "end_time": "2020-11-11T00:23:23.161790",
      "exception": false,
-     "start_time": "2020-11-10T04:08:32.267404",
+     "start_time": "2020-11-11T00:23:21.120306",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [],
    "source": [
-    "resp = requests.get(url1)\n",
-    "\n",
-    "with zipfile.ZipFile(io.BytesIO(resp.content), 'r') as zf:\n",
-    "    with zf.open('top_40_varieties.csv') as f:\n",
-    "        top_40_varieties = pd.read_csv(f)"
+    "top_40_varieties = pd.read_csv(url1)\n",
+    "top_varieties_count = pd.read_csv(url2)"
    ]
   },
   {
@@ -130,40 +123,16 @@
    "execution_count": 4,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:08:36.894689Z",
-     "iopub.status.busy": "2020-11-10T04:08:36.893982Z",
-     "iopub.status.idle": "2020-11-10T04:08:37.421192Z",
-     "shell.execute_reply": "2020-11-10T04:08:37.420026Z"
+     "iopub.execute_input": "2020-11-11T00:23:23.259292Z",
+     "iopub.status.busy": "2020-11-11T00:23:23.257590Z",
+     "iopub.status.idle": "2020-11-11T00:23:23.317570Z",
+     "shell.execute_reply": "2020-11-11T00:23:23.317038Z"
     },
     "papermill": {
-     "duration": 0.592593,
-     "end_time": "2020-11-10T04:08:37.421320",
+     "duration": 0.115617,
+     "end_time": "2020-11-11T00:23:23.317672",
      "exception": false,
-     "start_time": "2020-11-10T04:08:36.828727",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "top_varieties_count = pd.read_csv(url2)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2020-11-10T04:08:37.529424Z",
-     "iopub.status.busy": "2020-11-10T04:08:37.528260Z",
-     "iopub.status.idle": "2020-11-10T04:08:37.593221Z",
-     "shell.execute_reply": "2020-11-10T04:08:37.592664Z"
-    },
-    "papermill": {
-     "duration": 0.128253,
-     "end_time": "2020-11-10T04:08:37.593328",
-     "exception": false,
-     "start_time": "2020-11-10T04:08:37.465075",
+     "start_time": "2020-11-11T00:23:23.202055",
      "status": "completed"
     },
     "tags": []
@@ -180,19 +149,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:08:37.689068Z",
-     "iopub.status.busy": "2020-11-10T04:08:37.688074Z",
-     "iopub.status.idle": "2020-11-10T04:08:37.690451Z",
-     "shell.execute_reply": "2020-11-10T04:08:37.691088Z"
+     "iopub.execute_input": "2020-11-11T00:23:23.403459Z",
+     "iopub.status.busy": "2020-11-11T00:23:23.402674Z",
+     "iopub.status.idle": "2020-11-11T00:23:23.405861Z",
+     "shell.execute_reply": "2020-11-11T00:23:23.405267Z"
     },
     "papermill": {
-     "duration": 0.056006,
-     "end_time": "2020-11-10T04:08:37.691227",
+     "duration": 0.049791,
+     "end_time": "2020-11-11T00:23:23.405957",
      "exception": false,
-     "start_time": "2020-11-10T04:08:37.635221",
+     "start_time": "2020-11-11T00:23:23.356166",
      "status": "completed"
     },
     "tags": []
@@ -207,19 +176,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:08:37.794490Z",
-     "iopub.status.busy": "2020-11-10T04:08:37.793684Z",
-     "iopub.status.idle": "2020-11-10T04:08:37.819325Z",
-     "shell.execute_reply": "2020-11-10T04:08:37.818766Z"
+     "iopub.execute_input": "2020-11-11T00:23:23.544198Z",
+     "iopub.status.busy": "2020-11-11T00:23:23.543292Z",
+     "iopub.status.idle": "2020-11-11T00:23:23.594384Z",
+     "shell.execute_reply": "2020-11-11T00:23:23.595557Z"
     },
     "papermill": {
-     "duration": 0.084672,
-     "end_time": "2020-11-10T04:08:37.819446",
+     "duration": 0.132405,
+     "end_time": "2020-11-11T00:23:23.595753",
      "exception": false,
-     "start_time": "2020-11-10T04:08:37.734774",
+     "start_time": "2020-11-11T00:23:23.463348",
      "status": "completed"
     },
     "tags": []
@@ -234,19 +203,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:08:37.917325Z",
-     "iopub.status.busy": "2020-11-10T04:08:37.916280Z",
-     "iopub.status.idle": "2020-11-10T04:08:37.959634Z",
-     "shell.execute_reply": "2020-11-10T04:08:37.959039Z"
+     "iopub.execute_input": "2020-11-11T00:23:23.720702Z",
+     "iopub.status.busy": "2020-11-11T00:23:23.719282Z",
+     "iopub.status.idle": "2020-11-11T00:23:23.767123Z",
+     "shell.execute_reply": "2020-11-11T00:23:23.768305Z"
     },
     "papermill": {
-     "duration": 0.096195,
-     "end_time": "2020-11-10T04:08:37.959756",
+     "duration": 0.114555,
+     "end_time": "2020-11-11T00:23:23.768478",
      "exception": false,
-     "start_time": "2020-11-10T04:08:37.863561",
+     "start_time": "2020-11-11T00:23:23.653923",
      "status": "completed"
     },
     "tags": []
@@ -263,19 +232,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:08:38.050976Z",
-     "iopub.status.busy": "2020-11-10T04:08:38.050186Z",
-     "iopub.status.idle": "2020-11-10T04:08:38.849440Z",
-     "shell.execute_reply": "2020-11-10T04:08:38.848827Z"
+     "iopub.execute_input": "2020-11-11T00:23:23.895804Z",
+     "iopub.status.busy": "2020-11-11T00:23:23.894379Z",
+     "iopub.status.idle": "2020-11-11T00:23:24.619634Z",
+     "shell.execute_reply": "2020-11-11T00:23:24.618502Z"
     },
     "papermill": {
-     "duration": 0.846104,
-     "end_time": "2020-11-10T04:08:38.849569",
+     "duration": 0.794901,
+     "end_time": "2020-11-11T00:23:24.619755",
      "exception": false,
-     "start_time": "2020-11-10T04:08:38.003465",
+     "start_time": "2020-11-11T00:23:23.824854",
      "status": "completed"
     },
     "tags": []
@@ -287,19 +256,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:08:38.953040Z",
-     "iopub.status.busy": "2020-11-10T04:08:38.952024Z",
-     "iopub.status.idle": "2020-11-10T04:08:38.955365Z",
-     "shell.execute_reply": "2020-11-10T04:08:38.954817Z"
+     "iopub.execute_input": "2020-11-11T00:23:24.710492Z",
+     "iopub.status.busy": "2020-11-11T00:23:24.708752Z",
+     "iopub.status.idle": "2020-11-11T00:23:24.711252Z",
+     "shell.execute_reply": "2020-11-11T00:23:24.711730Z"
     },
     "papermill": {
-     "duration": 0.058739,
-     "end_time": "2020-11-10T04:08:38.955485",
+     "duration": 0.052765,
+     "end_time": "2020-11-11T00:23:24.711843",
      "exception": false,
-     "start_time": "2020-11-10T04:08:38.896746",
+     "start_time": "2020-11-11T00:23:24.659078",
      "status": "completed"
     },
     "tags": []
@@ -318,19 +287,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:08:39.046705Z",
-     "iopub.status.busy": "2020-11-10T04:08:39.046028Z",
-     "iopub.status.idle": "2020-11-10T04:08:48.512382Z",
-     "shell.execute_reply": "2020-11-10T04:08:48.511566Z"
+     "iopub.execute_input": "2020-11-11T00:23:24.794420Z",
+     "iopub.status.busy": "2020-11-11T00:23:24.793784Z",
+     "iopub.status.idle": "2020-11-11T00:23:33.459146Z",
+     "shell.execute_reply": "2020-11-11T00:23:33.458520Z"
     },
     "papermill": {
-     "duration": 9.513044,
-     "end_time": "2020-11-10T04:08:48.512505",
+     "duration": 8.708183,
+     "end_time": "2020-11-11T00:23:33.459269",
      "exception": false,
-     "start_time": "2020-11-10T04:08:38.999461",
+     "start_time": "2020-11-11T00:23:24.751086",
      "status": "completed"
     },
     "tags": []
@@ -342,19 +311,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:08:48.601684Z",
-     "iopub.status.busy": "2020-11-10T04:08:48.601041Z",
-     "iopub.status.idle": "2020-11-10T04:08:48.807215Z",
-     "shell.execute_reply": "2020-11-10T04:08:48.806646Z"
+     "iopub.execute_input": "2020-11-11T00:23:33.545673Z",
+     "iopub.status.busy": "2020-11-11T00:23:33.544916Z",
+     "iopub.status.idle": "2020-11-11T00:23:33.736498Z",
+     "shell.execute_reply": "2020-11-11T00:23:33.735937Z"
     },
     "papermill": {
-     "duration": 0.251907,
-     "end_time": "2020-11-10T04:08:48.807337",
+     "duration": 0.235514,
+     "end_time": "2020-11-11T00:23:33.736621",
      "exception": false,
-     "start_time": "2020-11-10T04:08:48.555430",
+     "start_time": "2020-11-11T00:23:33.501107",
      "status": "completed"
     },
     "tags": []
@@ -367,19 +336,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:08:48.913788Z",
-     "iopub.status.busy": "2020-11-10T04:08:48.912727Z",
-     "iopub.status.idle": "2020-11-10T04:08:49.150877Z",
-     "shell.execute_reply": "2020-11-10T04:08:49.150261Z"
+     "iopub.execute_input": "2020-11-11T00:23:33.833137Z",
+     "iopub.status.busy": "2020-11-11T00:23:33.832011Z",
+     "iopub.status.idle": "2020-11-11T00:23:34.049372Z",
+     "shell.execute_reply": "2020-11-11T00:23:34.048819Z"
     },
     "papermill": {
-     "duration": 0.300396,
-     "end_time": "2020-11-10T04:08:49.151005",
+     "duration": 0.272128,
+     "end_time": "2020-11-11T00:23:34.049487",
      "exception": false,
-     "start_time": "2020-11-10T04:08:48.850609",
+     "start_time": "2020-11-11T00:23:33.777359",
      "status": "completed"
     },
     "tags": []
@@ -397,19 +366,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:08:49.284226Z",
-     "iopub.status.busy": "2020-11-10T04:08:49.282278Z",
-     "iopub.status.idle": "2020-11-10T04:08:49.284955Z",
-     "shell.execute_reply": "2020-11-10T04:08:49.285489Z"
+     "iopub.execute_input": "2020-11-11T00:23:34.171700Z",
+     "iopub.status.busy": "2020-11-11T00:23:34.169786Z",
+     "iopub.status.idle": "2020-11-11T00:23:34.172545Z",
+     "shell.execute_reply": "2020-11-11T00:23:34.173053Z"
     },
     "papermill": {
-     "duration": 0.089954,
-     "end_time": "2020-11-10T04:08:49.285617",
+     "duration": 0.083683,
+     "end_time": "2020-11-11T00:23:34.173181",
      "exception": false,
-     "start_time": "2020-11-10T04:08:49.195663",
+     "start_time": "2020-11-11T00:23:34.089498",
      "status": "completed"
     },
     "tags": []
@@ -421,19 +390,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:08:49.375204Z",
-     "iopub.status.busy": "2020-11-10T04:08:49.374583Z",
-     "iopub.status.idle": "2020-11-10T04:08:49.378857Z",
-     "shell.execute_reply": "2020-11-10T04:08:49.378164Z"
+     "iopub.execute_input": "2020-11-11T00:23:34.257943Z",
+     "iopub.status.busy": "2020-11-11T00:23:34.257203Z",
+     "iopub.status.idle": "2020-11-11T00:23:34.260141Z",
+     "shell.execute_reply": "2020-11-11T00:23:34.259535Z"
     },
     "papermill": {
-     "duration": 0.051029,
-     "end_time": "2020-11-10T04:08:49.378991",
+     "duration": 0.04643,
+     "end_time": "2020-11-11T00:23:34.260263",
      "exception": false,
-     "start_time": "2020-11-10T04:08:49.327962",
+     "start_time": "2020-11-11T00:23:34.213833",
      "status": "completed"
     },
     "tags": []
@@ -446,19 +415,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:08:49.493334Z",
-     "iopub.status.busy": "2020-11-10T04:08:49.488305Z",
-     "iopub.status.idle": "2020-11-10T04:08:49.608662Z",
-     "shell.execute_reply": "2020-11-10T04:08:49.608049Z"
+     "iopub.execute_input": "2020-11-11T00:23:34.378742Z",
+     "iopub.status.busy": "2020-11-11T00:23:34.373587Z",
+     "iopub.status.idle": "2020-11-11T00:23:34.480752Z",
+     "shell.execute_reply": "2020-11-11T00:23:34.480115Z"
     },
     "papermill": {
-     "duration": 0.186636,
-     "end_time": "2020-11-10T04:08:49.608790",
+     "duration": 0.180675,
+     "end_time": "2020-11-11T00:23:34.480874",
      "exception": false,
-     "start_time": "2020-11-10T04:08:49.422154",
+     "start_time": "2020-11-11T00:23:34.300199",
      "status": "completed"
     },
     "tags": []
@@ -472,19 +441,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:08:49.745913Z",
-     "iopub.status.busy": "2020-11-10T04:08:49.744937Z",
-     "iopub.status.idle": "2020-11-10T04:08:49.841514Z",
-     "shell.execute_reply": "2020-11-10T04:08:49.840848Z"
+     "iopub.execute_input": "2020-11-11T00:23:34.610761Z",
+     "iopub.status.busy": "2020-11-11T00:23:34.590029Z",
+     "iopub.status.idle": "2020-11-11T00:23:34.694714Z",
+     "shell.execute_reply": "2020-11-11T00:23:34.694086Z"
     },
     "papermill": {
-     "duration": 0.190326,
-     "end_time": "2020-11-10T04:08:49.841655",
+     "duration": 0.173282,
+     "end_time": "2020-11-11T00:23:34.694835",
      "exception": false,
-     "start_time": "2020-11-10T04:08:49.651329",
+     "start_time": "2020-11-11T00:23:34.521553",
      "status": "completed"
     },
     "tags": []
@@ -507,10 +476,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.047918,
-     "end_time": "2020-11-10T04:08:49.938158",
+     "duration": 0.040916,
+     "end_time": "2020-11-11T00:23:34.776958",
      "exception": false,
-     "start_time": "2020-11-10T04:08:49.890240",
+     "start_time": "2020-11-11T00:23:34.736042",
      "status": "completed"
     },
     "tags": []
@@ -521,19 +490,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 17,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:08:50.028868Z",
-     "iopub.status.busy": "2020-11-10T04:08:50.028166Z",
-     "iopub.status.idle": "2020-11-10T04:08:52.699911Z",
-     "shell.execute_reply": "2020-11-10T04:08:52.699223Z"
+     "iopub.execute_input": "2020-11-11T00:23:34.863054Z",
+     "iopub.status.busy": "2020-11-11T00:23:34.862287Z",
+     "iopub.status.idle": "2020-11-11T00:23:36.998717Z",
+     "shell.execute_reply": "2020-11-11T00:23:36.999324Z"
     },
     "papermill": {
-     "duration": 2.718657,
-     "end_time": "2020-11-10T04:08:52.700044",
+     "duration": 2.182421,
+     "end_time": "2020-11-11T00:23:36.999499",
      "exception": false,
-     "start_time": "2020-11-10T04:08:49.981387",
+     "start_time": "2020-11-11T00:23:34.817078",
      "status": "completed"
     },
     "tags": []
@@ -545,19 +514,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 18,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:08:52.800632Z",
-     "iopub.status.busy": "2020-11-10T04:08:52.799663Z",
-     "iopub.status.idle": "2020-11-10T04:08:54.040691Z",
-     "shell.execute_reply": "2020-11-10T04:08:54.040119Z"
+     "iopub.execute_input": "2020-11-11T00:23:37.105143Z",
+     "iopub.status.busy": "2020-11-11T00:23:37.104386Z",
+     "iopub.status.idle": "2020-11-11T00:23:38.273892Z",
+     "shell.execute_reply": "2020-11-11T00:23:38.273338Z"
     },
     "papermill": {
-     "duration": 1.295807,
-     "end_time": "2020-11-10T04:08:54.040804",
+     "duration": 1.214667,
+     "end_time": "2020-11-11T00:23:38.274032",
      "exception": false,
-     "start_time": "2020-11-10T04:08:52.744997",
+     "start_time": "2020-11-11T00:23:37.059365",
      "status": "completed"
     },
     "tags": []
@@ -570,19 +539,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 19,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:08:54.137079Z",
-     "iopub.status.busy": "2020-11-10T04:08:54.136449Z",
-     "iopub.status.idle": "2020-11-10T04:08:54.140843Z",
-     "shell.execute_reply": "2020-11-10T04:08:54.140369Z"
+     "iopub.execute_input": "2020-11-11T00:23:38.358961Z",
+     "iopub.status.busy": "2020-11-11T00:23:38.358368Z",
+     "iopub.status.idle": "2020-11-11T00:23:38.362572Z",
+     "shell.execute_reply": "2020-11-11T00:23:38.362082Z"
     },
     "papermill": {
-     "duration": 0.055627,
-     "end_time": "2020-11-10T04:08:54.140942",
+     "duration": 0.048082,
+     "end_time": "2020-11-11T00:23:38.362671",
      "exception": false,
-     "start_time": "2020-11-10T04:08:54.085315",
+     "start_time": "2020-11-11T00:23:38.314589",
      "status": "completed"
     },
     "tags": []
@@ -594,19 +563,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 20,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:08:54.254530Z",
-     "iopub.status.busy": "2020-11-10T04:08:54.252604Z",
-     "iopub.status.idle": "2020-11-10T04:08:54.255203Z",
-     "shell.execute_reply": "2020-11-10T04:08:54.255749Z"
+     "iopub.execute_input": "2020-11-11T00:23:38.463915Z",
+     "iopub.status.busy": "2020-11-11T00:23:38.462634Z",
+     "iopub.status.idle": "2020-11-11T00:23:38.465217Z",
+     "shell.execute_reply": "2020-11-11T00:23:38.465822Z"
     },
     "papermill": {
-     "duration": 0.070255,
-     "end_time": "2020-11-10T04:08:54.255893",
+     "duration": 0.062904,
+     "end_time": "2020-11-11T00:23:38.465938",
      "exception": false,
-     "start_time": "2020-11-10T04:08:54.185638",
+     "start_time": "2020-11-11T00:23:38.403034",
      "status": "completed"
     },
     "tags": []
@@ -621,10 +590,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.044756,
-     "end_time": "2020-11-10T04:08:54.345158",
+     "duration": 0.040932,
+     "end_time": "2020-11-11T00:23:38.548041",
      "exception": false,
-     "start_time": "2020-11-10T04:08:54.300402",
+     "start_time": "2020-11-11T00:23:38.507109",
      "status": "completed"
     },
     "tags": []
@@ -635,19 +604,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 21,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:08:54.470566Z",
-     "iopub.status.busy": "2020-11-10T04:08:54.469219Z",
-     "iopub.status.idle": "2020-11-10T04:08:54.471568Z",
-     "shell.execute_reply": "2020-11-10T04:08:54.469845Z"
+     "iopub.execute_input": "2020-11-11T00:23:38.633271Z",
+     "iopub.status.busy": "2020-11-11T00:23:38.632518Z",
+     "iopub.status.idle": "2020-11-11T00:23:38.635498Z",
+     "shell.execute_reply": "2020-11-11T00:23:38.635037Z"
     },
     "papermill": {
-     "duration": 0.081562,
-     "end_time": "2020-11-10T04:08:54.471718",
+     "duration": 0.046944,
+     "end_time": "2020-11-11T00:23:38.635598",
      "exception": false,
-     "start_time": "2020-11-10T04:08:54.390156",
+     "start_time": "2020-11-11T00:23:38.588654",
      "status": "completed"
     },
     "tags": []
@@ -659,19 +628,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 22,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:08:54.585282Z",
-     "iopub.status.busy": "2020-11-10T04:08:54.584235Z",
-     "iopub.status.idle": "2020-11-10T04:08:54.587569Z",
-     "shell.execute_reply": "2020-11-10T04:08:54.586988Z"
+     "iopub.execute_input": "2020-11-11T00:23:38.726529Z",
+     "iopub.status.busy": "2020-11-11T00:23:38.725674Z",
+     "iopub.status.idle": "2020-11-11T00:23:38.730408Z",
+     "shell.execute_reply": "2020-11-11T00:23:38.729801Z"
     },
     "papermill": {
-     "duration": 0.064033,
-     "end_time": "2020-11-10T04:08:54.587688",
+     "duration": 0.054096,
+     "end_time": "2020-11-11T00:23:38.730502",
      "exception": false,
-     "start_time": "2020-11-10T04:08:54.523655",
+     "start_time": "2020-11-11T00:23:38.676406",
      "status": "completed"
     },
     "tags": []
@@ -703,19 +672,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 23,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:08:54.686865Z",
-     "iopub.status.busy": "2020-11-10T04:08:54.686196Z",
-     "iopub.status.idle": "2020-11-10T04:08:54.690630Z",
-     "shell.execute_reply": "2020-11-10T04:08:54.690043Z"
+     "iopub.execute_input": "2020-11-11T00:23:38.821353Z",
+     "iopub.status.busy": "2020-11-11T00:23:38.820503Z",
+     "iopub.status.idle": "2020-11-11T00:23:38.823244Z",
+     "shell.execute_reply": "2020-11-11T00:23:38.822689Z"
     },
     "papermill": {
-     "duration": 0.053968,
-     "end_time": "2020-11-10T04:08:54.690761",
+     "duration": 0.049046,
+     "end_time": "2020-11-11T00:23:38.823342",
      "exception": false,
-     "start_time": "2020-11-10T04:08:54.636793",
+     "start_time": "2020-11-11T00:23:38.774296",
      "status": "completed"
     },
     "tags": []
@@ -727,19 +696,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 24,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:08:54.800342Z",
-     "iopub.status.busy": "2020-11-10T04:08:54.799516Z",
-     "iopub.status.idle": "2020-11-10T04:09:00.995612Z",
-     "shell.execute_reply": "2020-11-10T04:09:00.996106Z"
+     "iopub.execute_input": "2020-11-11T00:23:38.909718Z",
+     "iopub.status.busy": "2020-11-11T00:23:38.909010Z",
+     "iopub.status.idle": "2020-11-11T00:23:43.485082Z",
+     "shell.execute_reply": "2020-11-11T00:23:43.484314Z"
     },
     "papermill": {
-     "duration": 6.255403,
-     "end_time": "2020-11-10T04:09:00.996252",
+     "duration": 4.620285,
+     "end_time": "2020-11-11T00:23:43.485205",
      "exception": false,
-     "start_time": "2020-11-10T04:08:54.740849",
+     "start_time": "2020-11-11T00:23:38.864920",
      "status": "completed"
     },
     "tags": []
@@ -752,19 +721,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 25,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:09:01.095476Z",
-     "iopub.status.busy": "2020-11-10T04:09:01.094797Z",
-     "iopub.status.idle": "2020-11-10T04:09:01.099438Z",
-     "shell.execute_reply": "2020-11-10T04:09:01.098840Z"
+     "iopub.execute_input": "2020-11-11T00:23:43.576374Z",
+     "iopub.status.busy": "2020-11-11T00:23:43.575539Z",
+     "iopub.status.idle": "2020-11-11T00:23:43.578305Z",
+     "shell.execute_reply": "2020-11-11T00:23:43.577819Z"
     },
     "papermill": {
-     "duration": 0.057583,
-     "end_time": "2020-11-10T04:09:01.099550",
+     "duration": 0.051726,
+     "end_time": "2020-11-11T00:23:43.578404",
      "exception": false,
-     "start_time": "2020-11-10T04:09:01.041967",
+     "start_time": "2020-11-11T00:23:43.526678",
      "status": "completed"
     },
     "tags": []
@@ -787,19 +756,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 26,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:09:01.196927Z",
-     "iopub.status.busy": "2020-11-10T04:09:01.196261Z",
-     "iopub.status.idle": "2020-11-10T04:09:01.200223Z",
-     "shell.execute_reply": "2020-11-10T04:09:01.199757Z"
+     "iopub.execute_input": "2020-11-11T00:23:43.664504Z",
+     "iopub.status.busy": "2020-11-11T00:23:43.663741Z",
+     "iopub.status.idle": "2020-11-11T00:23:43.666172Z",
+     "shell.execute_reply": "2020-11-11T00:23:43.666695Z"
     },
     "papermill": {
-     "duration": 0.053455,
-     "end_time": "2020-11-10T04:09:01.200321",
+     "duration": 0.047176,
+     "end_time": "2020-11-11T00:23:43.666801",
      "exception": false,
-     "start_time": "2020-11-10T04:09:01.146866",
+     "start_time": "2020-11-11T00:23:43.619625",
      "status": "completed"
     },
     "tags": []
@@ -811,19 +780,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 27,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:09:01.298853Z",
-     "iopub.status.busy": "2020-11-10T04:09:01.298006Z",
-     "iopub.status.idle": "2020-11-10T04:09:01.355933Z",
-     "shell.execute_reply": "2020-11-10T04:09:01.354485Z"
+     "iopub.execute_input": "2020-11-11T00:23:43.753512Z",
+     "iopub.status.busy": "2020-11-11T00:23:43.752818Z",
+     "iopub.status.idle": "2020-11-11T00:23:43.802144Z",
+     "shell.execute_reply": "2020-11-11T00:23:43.801520Z"
     },
     "papermill": {
-     "duration": 0.11003,
-     "end_time": "2020-11-10T04:09:01.356060",
+     "duration": 0.093872,
+     "end_time": "2020-11-11T00:23:43.802242",
      "exception": false,
-     "start_time": "2020-11-10T04:09:01.246030",
+     "start_time": "2020-11-11T00:23:43.708370",
      "status": "completed"
     },
     "tags": []
@@ -835,19 +804,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 28,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:09:01.465645Z",
-     "iopub.status.busy": "2020-11-10T04:09:01.464649Z",
-     "iopub.status.idle": "2020-11-10T04:09:01.467744Z",
-     "shell.execute_reply": "2020-11-10T04:09:01.467218Z"
+     "iopub.execute_input": "2020-11-11T00:23:43.892200Z",
+     "iopub.status.busy": "2020-11-11T00:23:43.891362Z",
+     "iopub.status.idle": "2020-11-11T00:23:43.893801Z",
+     "shell.execute_reply": "2020-11-11T00:23:43.894325Z"
     },
     "papermill": {
-     "duration": 0.065773,
-     "end_time": "2020-11-10T04:09:01.467852",
+     "duration": 0.050707,
+     "end_time": "2020-11-11T00:23:43.894432",
      "exception": false,
-     "start_time": "2020-11-10T04:09:01.402079",
+     "start_time": "2020-11-11T00:23:43.843725",
      "status": "completed"
     },
     "tags": []
@@ -868,19 +837,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 29,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:09:01.565107Z",
-     "iopub.status.busy": "2020-11-10T04:09:01.564256Z",
-     "iopub.status.idle": "2020-11-10T04:09:01.567300Z",
-     "shell.execute_reply": "2020-11-10T04:09:01.566839Z"
+     "iopub.execute_input": "2020-11-11T00:23:43.989249Z",
+     "iopub.status.busy": "2020-11-11T00:23:43.988483Z",
+     "iopub.status.idle": "2020-11-11T00:23:43.990942Z",
+     "shell.execute_reply": "2020-11-11T00:23:43.991528Z"
     },
     "papermill": {
-     "duration": 0.052094,
-     "end_time": "2020-11-10T04:09:01.567415",
+     "duration": 0.053798,
+     "end_time": "2020-11-11T00:23:43.991643",
      "exception": false,
-     "start_time": "2020-11-10T04:09:01.515321",
+     "start_time": "2020-11-11T00:23:43.937845",
      "status": "completed"
     },
     "tags": []
@@ -892,19 +861,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 30,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:09:01.662641Z",
-     "iopub.status.busy": "2020-11-10T04:09:01.661767Z",
-     "iopub.status.idle": "2020-11-10T04:09:01.665108Z",
-     "shell.execute_reply": "2020-11-10T04:09:01.664571Z"
+     "iopub.execute_input": "2020-11-11T00:23:44.079444Z",
+     "iopub.status.busy": "2020-11-11T00:23:44.078637Z",
+     "iopub.status.idle": "2020-11-11T00:23:44.081357Z",
+     "shell.execute_reply": "2020-11-11T00:23:44.080873Z"
     },
     "papermill": {
-     "duration": 0.05253,
-     "end_time": "2020-11-10T04:09:01.665210",
+     "duration": 0.047861,
+     "end_time": "2020-11-11T00:23:44.081451",
      "exception": false,
-     "start_time": "2020-11-10T04:09:01.612680",
+     "start_time": "2020-11-11T00:23:44.033590",
      "status": "completed"
     },
     "tags": []
@@ -916,19 +885,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 31,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:09:01.761586Z",
-     "iopub.status.busy": "2020-11-10T04:09:01.760692Z",
-     "iopub.status.idle": "2020-11-10T04:09:01.763596Z",
-     "shell.execute_reply": "2020-11-10T04:09:01.762960Z"
+     "iopub.execute_input": "2020-11-11T00:23:44.170675Z",
+     "iopub.status.busy": "2020-11-11T00:23:44.169889Z",
+     "iopub.status.idle": "2020-11-11T00:23:44.173087Z",
+     "shell.execute_reply": "2020-11-11T00:23:44.172561Z"
     },
     "papermill": {
-     "duration": 0.052644,
-     "end_time": "2020-11-10T04:09:01.763690",
+     "duration": 0.049512,
+     "end_time": "2020-11-11T00:23:44.173181",
      "exception": false,
-     "start_time": "2020-11-10T04:09:01.711046",
+     "start_time": "2020-11-11T00:23:44.123669",
      "status": "completed"
     },
     "tags": []
@@ -940,19 +909,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 32,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:09:01.897430Z",
-     "iopub.status.busy": "2020-11-10T04:09:01.887081Z",
-     "iopub.status.idle": "2020-11-10T04:10:22.452046Z",
-     "shell.execute_reply": "2020-11-10T04:10:22.451500Z"
+     "iopub.execute_input": "2020-11-11T00:23:44.270186Z",
+     "iopub.status.busy": "2020-11-11T00:23:44.264981Z",
+     "iopub.status.idle": "2020-11-11T00:24:57.750670Z",
+     "shell.execute_reply": "2020-11-11T00:24:57.750145Z"
     },
     "papermill": {
-     "duration": 80.641672,
-     "end_time": "2020-11-10T04:10:22.452163",
+     "duration": 73.535223,
+     "end_time": "2020-11-11T00:24:57.750795",
      "exception": false,
-     "start_time": "2020-11-10T04:09:01.810491",
+     "start_time": "2020-11-11T00:23:44.215572",
      "status": "completed"
     },
     "tags": []
@@ -966,10 +935,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.046163,
-     "end_time": "2020-11-10T04:10:22.547754",
+     "duration": 0.042018,
+     "end_time": "2020-11-11T00:24:57.835843",
      "exception": false,
-     "start_time": "2020-11-10T04:10:22.501591",
+     "start_time": "2020-11-11T00:24:57.793825",
      "status": "completed"
     },
     "tags": []
@@ -982,10 +951,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.046816,
-     "end_time": "2020-11-10T04:10:22.641465",
+     "duration": 0.042354,
+     "end_time": "2020-11-11T00:24:57.920393",
      "exception": false,
-     "start_time": "2020-11-10T04:10:22.594649",
+     "start_time": "2020-11-11T00:24:57.878039",
      "status": "completed"
     },
     "tags": []
@@ -996,19 +965,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 33,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:10:22.739599Z",
-     "iopub.status.busy": "2020-11-10T04:10:22.738842Z",
-     "iopub.status.idle": "2020-11-10T04:10:22.920705Z",
-     "shell.execute_reply": "2020-11-10T04:10:22.920004Z"
+     "iopub.execute_input": "2020-11-11T00:24:58.020241Z",
+     "iopub.status.busy": "2020-11-11T00:24:58.019598Z",
+     "iopub.status.idle": "2020-11-11T00:24:58.178533Z",
+     "shell.execute_reply": "2020-11-11T00:24:58.177912Z"
     },
     "papermill": {
-     "duration": 0.23335,
-     "end_time": "2020-11-10T04:10:22.920831",
+     "duration": 0.210713,
+     "end_time": "2020-11-11T00:24:58.178634",
      "exception": false,
-     "start_time": "2020-11-10T04:10:22.687481",
+     "start_time": "2020-11-11T00:24:57.967921",
      "status": "completed"
     },
     "tags": []
@@ -1020,19 +989,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 34,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:10:23.048312Z",
-     "iopub.status.busy": "2020-11-10T04:10:23.038005Z",
-     "iopub.status.idle": "2020-11-10T04:11:31.024699Z",
-     "shell.execute_reply": "2020-11-10T04:11:31.023495Z"
+     "iopub.execute_input": "2020-11-11T00:24:58.296340Z",
+     "iopub.status.busy": "2020-11-11T00:24:58.280918Z",
+     "iopub.status.idle": "2020-11-11T00:26:00.304165Z",
+     "shell.execute_reply": "2020-11-11T00:26:00.303561Z"
     },
     "papermill": {
-     "duration": 68.051519,
-     "end_time": "2020-11-10T04:11:31.024838",
+     "duration": 62.08334,
+     "end_time": "2020-11-11T00:26:00.304300",
      "exception": false,
-     "start_time": "2020-11-10T04:10:22.973319",
+     "start_time": "2020-11-11T00:24:58.220960",
      "status": "completed"
     },
     "tags": []
@@ -1045,19 +1014,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 35,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:11:31.166763Z",
-     "iopub.status.busy": "2020-11-10T04:11:31.146410Z",
-     "iopub.status.idle": "2020-11-10T04:13:26.094646Z",
-     "shell.execute_reply": "2020-11-10T04:13:26.093078Z"
+     "iopub.execute_input": "2020-11-11T00:26:00.430561Z",
+     "iopub.status.busy": "2020-11-11T00:26:00.404907Z",
+     "iopub.status.idle": "2020-11-11T00:27:31.868890Z",
+     "shell.execute_reply": "2020-11-11T00:27:31.868336Z"
     },
     "papermill": {
-     "duration": 115.023787,
-     "end_time": "2020-11-10T04:13:26.094800",
+     "duration": 91.521485,
+     "end_time": "2020-11-11T00:27:31.869026",
      "exception": false,
-     "start_time": "2020-11-10T04:11:31.071013",
+     "start_time": "2020-11-11T00:26:00.347541",
      "status": "completed"
     },
     "tags": []
@@ -1071,19 +1040,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 36,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:13:26.198059Z",
-     "iopub.status.busy": "2020-11-10T04:13:26.196271Z",
-     "iopub.status.idle": "2020-11-10T04:13:26.198845Z",
-     "shell.execute_reply": "2020-11-10T04:13:26.199320Z"
+     "iopub.execute_input": "2020-11-11T00:27:31.963743Z",
+     "iopub.status.busy": "2020-11-11T00:27:31.963142Z",
+     "iopub.status.idle": "2020-11-11T00:27:31.967188Z",
+     "shell.execute_reply": "2020-11-11T00:27:31.966669Z"
     },
     "papermill": {
-     "duration": 0.056788,
-     "end_time": "2020-11-10T04:13:26.199456",
+     "duration": 0.054126,
+     "end_time": "2020-11-11T00:27:31.967293",
      "exception": false,
-     "start_time": "2020-11-10T04:13:26.142668",
+     "start_time": "2020-11-11T00:27:31.913167",
      "status": "completed"
     },
     "tags": []
@@ -1104,19 +1073,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 37,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:13:26.303600Z",
-     "iopub.status.busy": "2020-11-10T04:13:26.295717Z",
-     "iopub.status.idle": "2020-11-10T04:13:26.713705Z",
-     "shell.execute_reply": "2020-11-10T04:13:26.714223Z"
+     "iopub.execute_input": "2020-11-11T00:27:32.061566Z",
+     "iopub.status.busy": "2020-11-11T00:27:32.060554Z",
+     "iopub.status.idle": "2020-11-11T00:27:32.465547Z",
+     "shell.execute_reply": "2020-11-11T00:27:32.464705Z"
     },
     "papermill": {
-     "duration": 0.469171,
-     "end_time": "2020-11-10T04:13:26.714397",
+     "duration": 0.453925,
+     "end_time": "2020-11-11T00:27:32.465676",
      "exception": false,
-     "start_time": "2020-11-10T04:13:26.245226",
+     "start_time": "2020-11-11T00:27:32.011751",
      "status": "completed"
     },
     "tags": []
@@ -1129,19 +1098,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 38,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:13:26.813827Z",
-     "iopub.status.busy": "2020-11-10T04:13:26.812943Z",
-     "iopub.status.idle": "2020-11-10T04:13:26.815645Z",
-     "shell.execute_reply": "2020-11-10T04:13:26.816119Z"
+     "iopub.execute_input": "2020-11-11T00:27:32.558503Z",
+     "iopub.status.busy": "2020-11-11T00:27:32.557669Z",
+     "iopub.status.idle": "2020-11-11T00:27:32.560432Z",
+     "shell.execute_reply": "2020-11-11T00:27:32.559833Z"
     },
     "papermill": {
-     "duration": 0.053405,
-     "end_time": "2020-11-10T04:13:26.816242",
+     "duration": 0.050684,
+     "end_time": "2020-11-11T00:27:32.560547",
      "exception": false,
-     "start_time": "2020-11-10T04:13:26.762837",
+     "start_time": "2020-11-11T00:27:32.509863",
      "status": "completed"
     },
     "tags": []
@@ -1153,19 +1122,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 39,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:13:26.963519Z",
-     "iopub.status.busy": "2020-11-10T04:13:26.962510Z",
-     "iopub.status.idle": "2020-11-10T04:13:26.976321Z",
-     "shell.execute_reply": "2020-11-10T04:13:26.976816Z"
+     "iopub.execute_input": "2020-11-11T00:27:32.697822Z",
+     "iopub.status.busy": "2020-11-11T00:27:32.696941Z",
+     "iopub.status.idle": "2020-11-11T00:27:32.709809Z",
+     "shell.execute_reply": "2020-11-11T00:27:32.710317Z"
     },
     "papermill": {
-     "duration": 0.113262,
-     "end_time": "2020-11-10T04:13:26.976942",
+     "duration": 0.10445,
+     "end_time": "2020-11-11T00:27:32.710439",
      "exception": false,
-     "start_time": "2020-11-10T04:13:26.863680",
+     "start_time": "2020-11-11T00:27:32.605989",
      "status": "completed"
     },
     "tags": []
@@ -1178,19 +1147,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 40,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:13:27.077900Z",
-     "iopub.status.busy": "2020-11-10T04:13:27.077119Z",
-     "iopub.status.idle": "2020-11-10T04:13:27.080196Z",
-     "shell.execute_reply": "2020-11-10T04:13:27.079688Z"
+     "iopub.execute_input": "2020-11-11T00:27:32.804142Z",
+     "iopub.status.busy": "2020-11-11T00:27:32.803142Z",
+     "iopub.status.idle": "2020-11-11T00:27:32.806725Z",
+     "shell.execute_reply": "2020-11-11T00:27:32.806145Z"
     },
     "papermill": {
-     "duration": 0.055616,
-     "end_time": "2020-11-10T04:13:27.080317",
+     "duration": 0.052492,
+     "end_time": "2020-11-11T00:27:32.806814",
      "exception": false,
-     "start_time": "2020-11-10T04:13:27.024701",
+     "start_time": "2020-11-11T00:27:32.754322",
      "status": "completed"
     },
     "tags": []
@@ -1207,10 +1176,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.047231,
-     "end_time": "2020-11-10T04:13:27.175966",
+     "duration": 0.043602,
+     "end_time": "2020-11-11T00:27:32.894647",
      "exception": false,
-     "start_time": "2020-11-10T04:13:27.128735",
+     "start_time": "2020-11-11T00:27:32.851045",
      "status": "completed"
     },
     "tags": []
@@ -1221,19 +1190,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 41,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:13:27.282647Z",
-     "iopub.status.busy": "2020-11-10T04:13:27.281913Z",
-     "iopub.status.idle": "2020-11-10T04:13:27.286298Z",
-     "shell.execute_reply": "2020-11-10T04:13:27.285708Z"
+     "iopub.execute_input": "2020-11-11T00:27:33.003860Z",
+     "iopub.status.busy": "2020-11-11T00:27:33.002107Z",
+     "iopub.status.idle": "2020-11-11T00:27:33.004638Z",
+     "shell.execute_reply": "2020-11-11T00:27:33.005125Z"
     },
     "papermill": {
-     "duration": 0.063107,
-     "end_time": "2020-11-10T04:13:27.286435",
+     "duration": 0.066563,
+     "end_time": "2020-11-11T00:27:33.005236",
      "exception": false,
-     "start_time": "2020-11-10T04:13:27.223328",
+     "start_time": "2020-11-11T00:27:32.938673",
      "status": "completed"
     },
     "tags": []
@@ -1270,19 +1239,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 42,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:13:27.423250Z",
-     "iopub.status.busy": "2020-11-10T04:13:27.422617Z",
-     "iopub.status.idle": "2020-11-10T04:13:27.427049Z",
-     "shell.execute_reply": "2020-11-10T04:13:27.426340Z"
+     "iopub.execute_input": "2020-11-11T00:27:33.099603Z",
+     "iopub.status.busy": "2020-11-11T00:27:33.097738Z",
+     "iopub.status.idle": "2020-11-11T00:27:33.100281Z",
+     "shell.execute_reply": "2020-11-11T00:27:33.100868Z"
     },
     "papermill": {
-     "duration": 0.094523,
-     "end_time": "2020-11-10T04:13:27.427164",
+     "duration": 0.051654,
+     "end_time": "2020-11-11T00:27:33.101016",
      "exception": false,
-     "start_time": "2020-11-10T04:13:27.332641",
+     "start_time": "2020-11-11T00:27:33.049362",
      "status": "completed"
     },
     "tags": []
@@ -1294,19 +1263,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 43,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:13:27.531496Z",
-     "iopub.status.busy": "2020-11-10T04:13:27.529779Z",
-     "iopub.status.idle": "2020-11-10T04:13:27.532496Z",
-     "shell.execute_reply": "2020-11-10T04:13:27.533008Z"
+     "iopub.execute_input": "2020-11-11T00:27:33.199384Z",
+     "iopub.status.busy": "2020-11-11T00:27:33.198652Z",
+     "iopub.status.idle": "2020-11-11T00:27:33.202806Z",
+     "shell.execute_reply": "2020-11-11T00:27:33.202262Z"
     },
     "papermill": {
-     "duration": 0.059745,
-     "end_time": "2020-11-10T04:13:27.533119",
+     "duration": 0.056614,
+     "end_time": "2020-11-11T00:27:33.202898",
      "exception": false,
-     "start_time": "2020-11-10T04:13:27.473374",
+     "start_time": "2020-11-11T00:27:33.146284",
      "status": "completed"
     },
     "tags": []
@@ -1338,19 +1307,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 44,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:13:27.633246Z",
-     "iopub.status.busy": "2020-11-10T04:13:27.632621Z",
-     "iopub.status.idle": "2020-11-10T04:13:27.635516Z",
-     "shell.execute_reply": "2020-11-10T04:13:27.636048Z"
+     "iopub.execute_input": "2020-11-11T00:27:33.297801Z",
+     "iopub.status.busy": "2020-11-11T00:27:33.296444Z",
+     "iopub.status.idle": "2020-11-11T00:27:33.299024Z",
+     "shell.execute_reply": "2020-11-11T00:27:33.299457Z"
     },
     "papermill": {
-     "duration": 0.055259,
-     "end_time": "2020-11-10T04:13:27.636170",
+     "duration": 0.052224,
+     "end_time": "2020-11-11T00:27:33.299565",
      "exception": false,
-     "start_time": "2020-11-10T04:13:27.580911",
+     "start_time": "2020-11-11T00:27:33.247341",
      "status": "completed"
     },
     "tags": []
@@ -1364,19 +1333,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 45,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:13:27.739879Z",
-     "iopub.status.busy": "2020-11-10T04:13:27.738885Z",
-     "iopub.status.idle": "2020-11-10T04:13:27.742293Z",
-     "shell.execute_reply": "2020-11-10T04:13:27.741617Z"
+     "iopub.execute_input": "2020-11-11T00:27:33.394136Z",
+     "iopub.status.busy": "2020-11-11T00:27:33.393399Z",
+     "iopub.status.idle": "2020-11-11T00:27:33.396478Z",
+     "shell.execute_reply": "2020-11-11T00:27:33.396008Z"
     },
     "papermill": {
-     "duration": 0.058252,
-     "end_time": "2020-11-10T04:13:27.742413",
+     "duration": 0.051689,
+     "end_time": "2020-11-11T00:27:33.396574",
      "exception": false,
-     "start_time": "2020-11-10T04:13:27.684161",
+     "start_time": "2020-11-11T00:27:33.344885",
      "status": "completed"
     },
     "tags": []
@@ -1388,19 +1357,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 46,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:13:27.893593Z",
-     "iopub.status.busy": "2020-11-10T04:13:27.888501Z",
-     "iopub.status.idle": "2020-11-10T04:15:33.097059Z",
-     "shell.execute_reply": "2020-11-10T04:15:33.097611Z"
+     "iopub.execute_input": "2020-11-11T00:27:33.507546Z",
+     "iopub.status.busy": "2020-11-11T00:27:33.497220Z",
+     "iopub.status.idle": "2020-11-11T00:29:30.115552Z",
+     "shell.execute_reply": "2020-11-11T00:29:30.116066Z"
     },
     "papermill": {
-     "duration": 125.302526,
-     "end_time": "2020-11-10T04:15:33.097789",
+     "duration": 116.672637,
+     "end_time": "2020-11-11T00:29:30.116191",
      "exception": false,
-     "start_time": "2020-11-10T04:13:27.795263",
+     "start_time": "2020-11-11T00:27:33.443554",
      "status": "completed"
     },
     "tags": []
@@ -1414,11 +1383,11 @@
        "                                 ('text_2_sequence', Text2Sequence()),\n",
        "                                 ('padding', Padding())])),\n",
        "                ('model',\n",
-       "                 <tensorflow.python.keras.wrappers.scikit_learn.KerasClassifier object at 0x7f45585e1210>)],\n",
+       "                 <tensorflow.python.keras.wrappers.scikit_learn.KerasClassifier object at 0x7f74f6b1b8d0>)],\n",
        "         verbose=0)"
       ]
      },
-     "execution_count": 47,
+     "execution_count": 46,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1431,10 +1400,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.048442,
-     "end_time": "2020-11-10T04:15:33.196640",
+     "duration": 0.045466,
+     "end_time": "2020-11-11T00:29:30.206756",
      "exception": false,
-     "start_time": "2020-11-10T04:15:33.148198",
+     "start_time": "2020-11-11T00:29:30.161290",
      "status": "completed"
     },
     "tags": []
@@ -1447,10 +1416,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.04808,
-     "end_time": "2020-11-10T04:15:33.294093",
+     "duration": 0.044465,
+     "end_time": "2020-11-11T00:29:30.296092",
      "exception": false,
-     "start_time": "2020-11-10T04:15:33.246013",
+     "start_time": "2020-11-11T00:29:30.251627",
      "status": "completed"
     },
     "tags": []
@@ -1461,19 +1430,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 47,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:15:33.396658Z",
-     "iopub.status.busy": "2020-11-10T04:15:33.394854Z",
-     "iopub.status.idle": "2020-11-10T04:15:33.397560Z",
-     "shell.execute_reply": "2020-11-10T04:15:33.398193Z"
+     "iopub.execute_input": "2020-11-11T00:29:30.390219Z",
+     "iopub.status.busy": "2020-11-11T00:29:30.389583Z",
+     "iopub.status.idle": "2020-11-11T00:29:30.393955Z",
+     "shell.execute_reply": "2020-11-11T00:29:30.393462Z"
     },
     "papermill": {
-     "duration": 0.055477,
-     "end_time": "2020-11-10T04:15:33.398316",
+     "duration": 0.053179,
+     "end_time": "2020-11-11T00:29:30.394076",
      "exception": false,
-     "start_time": "2020-11-10T04:15:33.342839",
+     "start_time": "2020-11-11T00:29:30.340897",
      "status": "completed"
     },
     "tags": []
@@ -1485,19 +1454,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 48,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:15:33.500378Z",
-     "iopub.status.busy": "2020-11-10T04:15:33.499715Z",
-     "iopub.status.idle": "2020-11-10T04:15:33.503407Z",
-     "shell.execute_reply": "2020-11-10T04:15:33.504020Z"
+     "iopub.execute_input": "2020-11-11T00:29:30.488741Z",
+     "iopub.status.busy": "2020-11-11T00:29:30.487447Z",
+     "iopub.status.idle": "2020-11-11T00:29:30.489926Z",
+     "shell.execute_reply": "2020-11-11T00:29:30.490436Z"
     },
     "papermill": {
-     "duration": 0.057085,
-     "end_time": "2020-11-10T04:15:33.504143",
+     "duration": 0.05163,
+     "end_time": "2020-11-11T00:29:30.490544",
      "exception": false,
-     "start_time": "2020-11-10T04:15:33.447058",
+     "start_time": "2020-11-11T00:29:30.438914",
      "status": "completed"
     },
     "tags": []
@@ -1515,10 +1484,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.049044,
-     "end_time": "2020-11-10T04:15:33.601430",
+     "duration": 0.045102,
+     "end_time": "2020-11-11T00:29:30.581024",
      "exception": false,
-     "start_time": "2020-11-10T04:15:33.552386",
+     "start_time": "2020-11-11T00:29:30.535922",
      "status": "completed"
     },
     "tags": []
@@ -1531,10 +1500,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.048959,
-     "end_time": "2020-11-10T04:15:33.699993",
+     "duration": 0.045203,
+     "end_time": "2020-11-11T00:29:30.671749",
      "exception": false,
-     "start_time": "2020-11-10T04:15:33.651034",
+     "start_time": "2020-11-11T00:29:30.626546",
      "status": "completed"
     },
     "tags": []
@@ -1545,19 +1514,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 49,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:15:33.815839Z",
-     "iopub.status.busy": "2020-11-10T04:15:33.815011Z",
-     "iopub.status.idle": "2020-11-10T04:15:33.824459Z",
-     "shell.execute_reply": "2020-11-10T04:15:33.823941Z"
+     "iopub.execute_input": "2020-11-11T00:29:30.777387Z",
+     "iopub.status.busy": "2020-11-11T00:29:30.776624Z",
+     "iopub.status.idle": "2020-11-11T00:29:30.786077Z",
+     "shell.execute_reply": "2020-11-11T00:29:30.786515Z"
     },
     "papermill": {
-     "duration": 0.07524,
-     "end_time": "2020-11-10T04:15:33.824553",
+     "duration": 0.069219,
+     "end_time": "2020-11-11T00:29:30.786634",
      "exception": false,
-     "start_time": "2020-11-10T04:15:33.749313",
+     "start_time": "2020-11-11T00:29:30.717415",
      "status": "completed"
     },
     "tags": []
@@ -1574,7 +1543,7 @@
        "       'Tempranillo'], dtype=object)"
       ]
      },
-     "execution_count": 50,
+     "execution_count": 49,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1587,10 +1556,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.053583,
-     "end_time": "2020-11-10T04:15:33.927844",
+     "duration": 0.045587,
+     "end_time": "2020-11-11T00:29:30.877795",
      "exception": false,
-     "start_time": "2020-11-10T04:15:33.874261",
+     "start_time": "2020-11-11T00:29:30.832208",
      "status": "completed"
     },
     "tags": []
@@ -1601,19 +1570,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 50,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:15:34.038895Z",
-     "iopub.status.busy": "2020-11-10T04:15:34.038086Z",
-     "iopub.status.idle": "2020-11-10T04:15:34.041666Z",
-     "shell.execute_reply": "2020-11-10T04:15:34.042144Z"
+     "iopub.execute_input": "2020-11-11T00:29:30.975889Z",
+     "iopub.status.busy": "2020-11-11T00:29:30.974329Z",
+     "iopub.status.idle": "2020-11-11T00:29:30.976909Z",
+     "shell.execute_reply": "2020-11-11T00:29:30.977399Z"
     },
     "papermill": {
-     "duration": 0.059519,
-     "end_time": "2020-11-10T04:15:34.042322",
+     "duration": 0.053515,
+     "end_time": "2020-11-11T00:29:30.977506",
      "exception": false,
-     "start_time": "2020-11-10T04:15:33.982803",
+     "start_time": "2020-11-11T00:29:30.923991",
      "status": "completed"
     },
     "tags": []
@@ -1630,33 +1599,33 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.051798,
-     "end_time": "2020-11-10T04:15:34.146309",
+     "duration": 0.045581,
+     "end_time": "2020-11-11T00:29:31.068926",
      "exception": false,
-     "start_time": "2020-11-10T04:15:34.094511",
+     "start_time": "2020-11-11T00:29:31.023345",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "### Notice the double quotes we used. This is top prevent error should the user's input contain apostrophe."
+    "### Notice the double quotes we used. This is to prevent error should the user's input contain apostrophe."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 51,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:15:34.257323Z",
-     "iopub.status.busy": "2020-11-10T04:15:34.256474Z",
-     "iopub.status.idle": "2020-11-10T04:15:34.260316Z",
-     "shell.execute_reply": "2020-11-10T04:15:34.260823Z"
+     "iopub.execute_input": "2020-11-11T00:29:31.165407Z",
+     "iopub.status.busy": "2020-11-11T00:29:31.164783Z",
+     "iopub.status.idle": "2020-11-11T00:29:31.170421Z",
+     "shell.execute_reply": "2020-11-11T00:29:31.169935Z"
     },
     "papermill": {
-     "duration": 0.062189,
-     "end_time": "2020-11-10T04:15:34.260942",
+     "duration": 0.055099,
+     "end_time": "2020-11-11T00:29:31.170529",
      "exception": false,
-     "start_time": "2020-11-10T04:15:34.198753",
+     "start_time": "2020-11-11T00:29:31.115430",
      "status": "completed"
     },
     "tags": []
@@ -1668,7 +1637,7 @@
        "'Juicy and richly interwoven with a fresh underlay of acidity, this powerhouse blend is substantially etched in cassis, plum and red currant. The oak and tannin are equally substantial and present, contributing weight, breadth and length. This will do well to cellar; enjoy best from 2027–2032'"
       ]
      },
-     "execution_count": 52,
+     "execution_count": 51,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1679,19 +1648,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 52,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-10T04:15:34.422847Z",
-     "iopub.status.busy": "2020-11-10T04:15:34.421929Z",
-     "iopub.status.idle": "2020-11-10T04:15:34.584598Z",
-     "shell.execute_reply": "2020-11-10T04:15:34.585132Z"
+     "iopub.execute_input": "2020-11-11T00:29:31.326121Z",
+     "iopub.status.busy": "2020-11-11T00:29:31.325274Z",
+     "iopub.status.idle": "2020-11-11T00:29:31.469406Z",
+     "shell.execute_reply": "2020-11-11T00:29:31.468522Z"
     },
     "papermill": {
-     "duration": 0.2761,
-     "end_time": "2020-11-10T04:15:34.585314",
+     "duration": 0.251686,
+     "end_time": "2020-11-11T00:29:31.469515",
      "exception": false,
-     "start_time": "2020-11-10T04:15:34.309214",
+     "start_time": "2020-11-11T00:29:31.217829",
      "status": "completed"
     },
     "tags": []
@@ -1717,10 +1686,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.05268,
-     "end_time": "2020-11-10T04:15:34.688762",
+     "duration": 0.046566,
+     "end_time": "2020-11-11T00:29:31.563079",
      "exception": false,
-     "start_time": "2020-11-10T04:15:34.636082",
+     "start_time": "2020-11-11T00:29:31.516513",
      "status": "completed"
     },
     "tags": []
@@ -1749,14 +1718,14 @@
    "version": "3.7.6"
   },
   "papermill": {
-   "duration": 430.675991,
-   "end_time": "2020-11-10T04:15:36.668166",
+   "duration": 377.112774,
+   "end_time": "2020-11-11T00:29:33.213002",
    "environment_variables": {},
    "exception": null,
    "input_path": "__notebook__.ipynb",
    "output_path": "__notebook__.ipynb",
    "parameters": {},
-   "start_time": "2020-11-10T04:08:25.992175",
+   "start_time": "2020-11-11T00:23:16.100228",
    "version": "2.1.0"
   }
  },


### PR DESCRIPTION
I loaded in the zipped top_40_varieties dataset using only pandas. I initially used requests, io, and zipfile libraries but have found out that pandas can do unzipping before reading csv files. So, no need to use requests, io, and zipfile libraries again.

Find the notebook [here](https://github.com/Jolomi-Tosanwumi/stage-f-06-wine-tasting/blob/master/pipeline/cnn-pipeline-model.ipynb)