### PR TITLE
Calculated the f1_score between output of padding and blender

### DIFF
--- a/model/final-model-cnn-lstm.ipynb
+++ b/model/final-model-cnn-lstm.ipynb
@@ -4,10 +4,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.042977,
-     "end_time": "2020-11-13T16:26:32.016760",
+     "duration": 0.051539,
+     "end_time": "2020-11-14T07:16:08.925701",
      "exception": false,
-     "start_time": "2020-11-13T16:26:31.973783",
+     "start_time": "2020-11-14T07:16:08.874162",
      "status": "completed"
     },
     "tags": []
@@ -21,16 +21,16 @@
    "execution_count": 1,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-13T16:26:32.105527Z",
-     "iopub.status.busy": "2020-11-13T16:26:32.104765Z",
-     "iopub.status.idle": "2020-11-13T16:26:37.211071Z",
-     "shell.execute_reply": "2020-11-13T16:26:37.211910Z"
+     "iopub.execute_input": "2020-11-14T07:16:09.036501Z",
+     "iopub.status.busy": "2020-11-14T07:16:09.035708Z",
+     "iopub.status.idle": "2020-11-14T07:16:14.377850Z",
+     "shell.execute_reply": "2020-11-14T07:16:14.381700Z"
     },
     "papermill": {
-     "duration": 5.154399,
-     "end_time": "2020-11-13T16:26:37.212143",
+     "duration": 5.403605,
+     "end_time": "2020-11-14T07:16:14.381948",
      "exception": false,
-     "start_time": "2020-11-13T16:26:32.057744",
+     "start_time": "2020-11-14T07:16:08.978343",
      "status": "completed"
     },
     "tags": []
@@ -47,16 +47,16 @@
    "execution_count": 2,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-13T16:26:37.336307Z",
-     "iopub.status.busy": "2020-11-13T16:26:37.335232Z",
-     "iopub.status.idle": "2020-11-13T16:26:37.337733Z",
-     "shell.execute_reply": "2020-11-13T16:26:37.337059Z"
+     "iopub.execute_input": "2020-11-14T07:16:14.585840Z",
+     "iopub.status.busy": "2020-11-14T07:16:14.584569Z",
+     "iopub.status.idle": "2020-11-14T07:16:14.589442Z",
+     "shell.execute_reply": "2020-11-14T07:16:14.590237Z"
     },
     "papermill": {
-     "duration": 0.064242,
-     "end_time": "2020-11-13T16:26:37.337849",
+     "duration": 0.098857,
+     "end_time": "2020-11-14T07:16:14.590463",
      "exception": false,
-     "start_time": "2020-11-13T16:26:37.273607",
+     "start_time": "2020-11-14T07:16:14.491606",
      "status": "completed"
     },
     "tags": []
@@ -73,16 +73,16 @@
    "execution_count": 3,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-13T16:26:37.463618Z",
-     "iopub.status.busy": "2020-11-13T16:26:37.462814Z",
-     "iopub.status.idle": "2020-11-13T16:26:38.546854Z",
-     "shell.execute_reply": "2020-11-13T16:26:38.545642Z"
+     "iopub.execute_input": "2020-11-14T07:16:14.775761Z",
+     "iopub.status.busy": "2020-11-14T07:16:14.774645Z",
+     "iopub.status.idle": "2020-11-14T07:16:15.784573Z",
+     "shell.execute_reply": "2020-11-14T07:16:15.783615Z"
     },
     "papermill": {
-     "duration": 1.152059,
-     "end_time": "2020-11-13T16:26:38.546985",
+     "duration": 1.107158,
+     "end_time": "2020-11-14T07:16:15.784705",
      "exception": false,
-     "start_time": "2020-11-13T16:26:37.394926",
+     "start_time": "2020-11-14T07:16:14.677547",
      "status": "completed"
     },
     "tags": []
@@ -103,6 +103,7 @@
     "\n",
     "from sklearn.preprocessing import LabelEncoder, OneHotEncoder\n",
     "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.metrics import accuracy_score, f1_score\n",
     "from sklearn.utils import class_weight\n",
     "from sklearn.pipeline import Pipeline, FeatureUnion\n",
     "from sklearn.base import BaseEstimator, TransformerMixin, ClassifierMixin\n",
@@ -112,6 +113,7 @@
     "from tensorflow.keras.preprocessing.sequence import pad_sequences\n",
     "from tensorflow.keras.layers import Embedding, Dense, GlobalMaxPool1D, Conv1D, Dropout, LSTM, Bidirectional\n",
     "from tensorflow.keras.models import Sequential\n",
+    "from tensorflow.keras.optimizers import Adam\n",
     "from tensorflow.keras.wrappers.scikit_learn import KerasClassifier\n",
     "\n",
     "from gensim.models import Word2Vec # importing Word2Vec"
@@ -121,10 +123,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.041622,
-     "end_time": "2020-11-13T16:26:38.631668",
+     "duration": 0.050333,
+     "end_time": "2020-11-14T07:16:15.884654",
      "exception": false,
-     "start_time": "2020-11-13T16:26:38.590046",
+     "start_time": "2020-11-14T07:16:15.834321",
      "status": "completed"
     },
     "tags": []
@@ -138,16 +140,16 @@
    "execution_count": 4,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-13T16:26:38.732108Z",
-     "iopub.status.busy": "2020-11-13T16:26:38.731099Z",
-     "iopub.status.idle": "2020-11-13T16:26:38.733808Z",
-     "shell.execute_reply": "2020-11-13T16:26:38.733220Z"
+     "iopub.execute_input": "2020-11-14T07:16:15.991838Z",
+     "iopub.status.busy": "2020-11-14T07:16:15.991025Z",
+     "iopub.status.idle": "2020-11-14T07:16:15.995409Z",
+     "shell.execute_reply": "2020-11-14T07:16:15.994845Z"
     },
     "papermill": {
-     "duration": 0.053833,
-     "end_time": "2020-11-13T16:26:38.733905",
+     "duration": 0.060266,
+     "end_time": "2020-11-14T07:16:15.995513",
      "exception": false,
-     "start_time": "2020-11-13T16:26:38.680072",
+     "start_time": "2020-11-14T07:16:15.935247",
      "status": "completed"
     },
     "tags": []
@@ -163,16 +165,16 @@
    "execution_count": 5,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-13T16:26:38.830205Z",
-     "iopub.status.busy": "2020-11-13T16:26:38.829481Z",
-     "iopub.status.idle": "2020-11-13T16:26:43.374710Z",
-     "shell.execute_reply": "2020-11-13T16:26:43.374107Z"
+     "iopub.execute_input": "2020-11-14T07:16:16.117760Z",
+     "iopub.status.busy": "2020-11-14T07:16:16.116989Z",
+     "iopub.status.idle": "2020-11-14T07:16:20.585689Z",
+     "shell.execute_reply": "2020-11-14T07:16:20.585078Z"
     },
     "papermill": {
-     "duration": 4.599708,
-     "end_time": "2020-11-13T16:26:43.374831",
+     "duration": 4.537467,
+     "end_time": "2020-11-14T07:16:20.585810",
      "exception": false,
-     "start_time": "2020-11-13T16:26:38.775123",
+     "start_time": "2020-11-14T07:16:16.048343",
      "status": "completed"
     },
     "tags": []
@@ -188,16 +190,16 @@
    "execution_count": 6,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-13T16:26:43.479926Z",
-     "iopub.status.busy": "2020-11-13T16:26:43.478897Z",
-     "iopub.status.idle": "2020-11-13T16:26:43.543855Z",
-     "shell.execute_reply": "2020-11-13T16:26:43.543196Z"
+     "iopub.execute_input": "2020-11-14T07:16:20.708696Z",
+     "iopub.status.busy": "2020-11-14T07:16:20.707551Z",
+     "iopub.status.idle": "2020-11-14T07:16:20.772719Z",
+     "shell.execute_reply": "2020-11-14T07:16:20.772153Z"
     },
     "papermill": {
-     "duration": 0.127515,
-     "end_time": "2020-11-13T16:26:43.543987",
+     "duration": 0.13584,
+     "end_time": "2020-11-14T07:16:20.772841",
      "exception": false,
-     "start_time": "2020-11-13T16:26:43.416472",
+     "start_time": "2020-11-14T07:16:20.637001",
      "status": "completed"
     },
     "tags": []
@@ -217,16 +219,16 @@
    "execution_count": 7,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-13T16:26:43.641233Z",
-     "iopub.status.busy": "2020-11-13T16:26:43.640351Z",
-     "iopub.status.idle": "2020-11-13T16:26:43.642816Z",
-     "shell.execute_reply": "2020-11-13T16:26:43.643287Z"
+     "iopub.execute_input": "2020-11-14T07:16:20.884696Z",
+     "iopub.status.busy": "2020-11-14T07:16:20.883743Z",
+     "iopub.status.idle": "2020-11-14T07:16:20.886928Z",
+     "shell.execute_reply": "2020-11-14T07:16:20.886405Z"
     },
     "papermill": {
-     "duration": 0.054979,
-     "end_time": "2020-11-13T16:26:43.643422",
+     "duration": 0.063953,
+     "end_time": "2020-11-14T07:16:20.887038",
      "exception": false,
-     "start_time": "2020-11-13T16:26:43.588443",
+     "start_time": "2020-11-14T07:16:20.823085",
      "status": "completed"
     },
     "tags": []
@@ -244,16 +246,16 @@
    "execution_count": 8,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-13T16:26:43.746990Z",
-     "iopub.status.busy": "2020-11-13T16:26:43.746217Z",
-     "iopub.status.idle": "2020-11-13T16:26:43.770818Z",
-     "shell.execute_reply": "2020-11-13T16:26:43.770276Z"
+     "iopub.execute_input": "2020-11-14T07:16:21.004518Z",
+     "iopub.status.busy": "2020-11-14T07:16:21.003729Z",
+     "iopub.status.idle": "2020-11-14T07:16:21.029227Z",
+     "shell.execute_reply": "2020-11-14T07:16:21.029761Z"
     },
     "papermill": {
-     "duration": 0.084202,
-     "end_time": "2020-11-13T16:26:43.770931",
+     "duration": 0.09347,
+     "end_time": "2020-11-14T07:16:21.029908",
      "exception": false,
-     "start_time": "2020-11-13T16:26:43.686729",
+     "start_time": "2020-11-14T07:16:20.936438",
      "status": "completed"
     },
     "tags": []
@@ -271,16 +273,16 @@
    "execution_count": 9,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-13T16:26:43.861563Z",
-     "iopub.status.busy": "2020-11-13T16:26:43.860722Z",
-     "iopub.status.idle": "2020-11-13T16:26:43.893666Z",
-     "shell.execute_reply": "2020-11-13T16:26:43.894120Z"
+     "iopub.execute_input": "2020-11-14T07:16:21.148612Z",
+     "iopub.status.busy": "2020-11-14T07:16:21.147669Z",
+     "iopub.status.idle": "2020-11-14T07:16:21.182158Z",
+     "shell.execute_reply": "2020-11-14T07:16:21.181662Z"
     },
     "papermill": {
-     "duration": 0.080688,
-     "end_time": "2020-11-13T16:26:43.894259",
+     "duration": 0.093022,
+     "end_time": "2020-11-14T07:16:21.182290",
      "exception": false,
-     "start_time": "2020-11-13T16:26:43.813571",
+     "start_time": "2020-11-14T07:16:21.089268",
      "status": "completed"
     },
     "tags": []
@@ -300,16 +302,16 @@
    "execution_count": 10,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-13T16:26:43.983258Z",
-     "iopub.status.busy": "2020-11-13T16:26:43.982518Z",
-     "iopub.status.idle": "2020-11-13T16:26:44.468495Z",
-     "shell.execute_reply": "2020-11-13T16:26:44.467963Z"
+     "iopub.execute_input": "2020-11-14T07:16:21.293112Z",
+     "iopub.status.busy": "2020-11-14T07:16:21.291022Z",
+     "iopub.status.idle": "2020-11-14T07:16:21.814613Z",
+     "shell.execute_reply": "2020-11-14T07:16:21.813981Z"
     },
     "papermill": {
-     "duration": 0.532159,
-     "end_time": "2020-11-13T16:26:44.468644",
+     "duration": 0.580282,
+     "end_time": "2020-11-14T07:16:21.814744",
      "exception": false,
-     "start_time": "2020-11-13T16:26:43.936485",
+     "start_time": "2020-11-14T07:16:21.234462",
      "status": "completed"
     },
     "tags": []
@@ -324,16 +326,16 @@
    "execution_count": 11,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-13T16:26:44.569009Z",
-     "iopub.status.busy": "2020-11-13T16:26:44.568126Z",
-     "iopub.status.idle": "2020-11-13T16:26:44.571170Z",
-     "shell.execute_reply": "2020-11-13T16:26:44.570704Z"
+     "iopub.execute_input": "2020-11-14T07:16:21.926646Z",
+     "iopub.status.busy": "2020-11-14T07:16:21.925904Z",
+     "iopub.status.idle": "2020-11-14T07:16:21.930036Z",
+     "shell.execute_reply": "2020-11-14T07:16:21.930568Z"
     },
     "papermill": {
-     "duration": 0.060379,
-     "end_time": "2020-11-13T16:26:44.571282",
+     "duration": 0.065652,
+     "end_time": "2020-11-14T07:16:21.930716",
      "exception": false,
-     "start_time": "2020-11-13T16:26:44.510903",
+     "start_time": "2020-11-14T07:16:21.865064",
      "status": "completed"
     },
     "tags": []
@@ -355,16 +357,16 @@
    "execution_count": 12,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-13T16:26:44.665025Z",
-     "iopub.status.busy": "2020-11-13T16:26:44.664068Z",
-     "iopub.status.idle": "2020-11-13T16:26:53.273726Z",
-     "shell.execute_reply": "2020-11-13T16:26:53.274282Z"
+     "iopub.execute_input": "2020-11-14T07:16:22.039802Z",
+     "iopub.status.busy": "2020-11-14T07:16:22.038997Z",
+     "iopub.status.idle": "2020-11-14T07:16:31.413498Z",
+     "shell.execute_reply": "2020-11-14T07:16:31.412566Z"
     },
     "papermill": {
-     "duration": 8.659148,
-     "end_time": "2020-11-13T16:26:53.274423",
+     "duration": 9.430947,
+     "end_time": "2020-11-14T07:16:31.413618",
      "exception": false,
-     "start_time": "2020-11-13T16:26:44.615275",
+     "start_time": "2020-11-14T07:16:21.982671",
      "status": "completed"
     },
     "tags": []
@@ -379,16 +381,16 @@
    "execution_count": 13,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-13T16:26:53.365431Z",
-     "iopub.status.busy": "2020-11-13T16:26:53.364812Z",
-     "iopub.status.idle": "2020-11-13T16:26:53.568959Z",
-     "shell.execute_reply": "2020-11-13T16:26:53.568317Z"
+     "iopub.execute_input": "2020-11-14T07:16:31.524485Z",
+     "iopub.status.busy": "2020-11-14T07:16:31.523807Z",
+     "iopub.status.idle": "2020-11-14T07:16:31.733602Z",
+     "shell.execute_reply": "2020-11-14T07:16:31.732951Z"
     },
     "papermill": {
-     "duration": 0.250848,
-     "end_time": "2020-11-13T16:26:53.569090",
+     "duration": 0.267949,
+     "end_time": "2020-11-14T07:16:31.733731",
      "exception": false,
-     "start_time": "2020-11-13T16:26:53.318242",
+     "start_time": "2020-11-14T07:16:31.465782",
      "status": "completed"
     },
     "tags": []
@@ -404,16 +406,16 @@
    "execution_count": 14,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-13T16:26:53.677990Z",
-     "iopub.status.busy": "2020-11-13T16:26:53.676850Z",
-     "iopub.status.idle": "2020-11-13T16:26:53.894068Z",
-     "shell.execute_reply": "2020-11-13T16:26:53.893506Z"
+     "iopub.execute_input": "2020-11-14T07:16:31.857211Z",
+     "iopub.status.busy": "2020-11-14T07:16:31.856055Z",
+     "iopub.status.idle": "2020-11-14T07:16:32.084412Z",
+     "shell.execute_reply": "2020-11-14T07:16:32.083782Z"
     },
     "papermill": {
-     "duration": 0.278024,
-     "end_time": "2020-11-13T16:26:53.894187",
+     "duration": 0.297417,
+     "end_time": "2020-11-14T07:16:32.084536",
      "exception": false,
-     "start_time": "2020-11-13T16:26:53.616163",
+     "start_time": "2020-11-14T07:16:31.787119",
      "status": "completed"
     },
     "tags": []
@@ -434,16 +436,16 @@
    "execution_count": 15,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-13T16:26:54.019436Z",
-     "iopub.status.busy": "2020-11-13T16:26:54.004081Z",
-     "iopub.status.idle": "2020-11-13T16:26:54.023343Z",
-     "shell.execute_reply": "2020-11-13T16:26:54.023802Z"
+     "iopub.execute_input": "2020-11-14T07:16:32.241189Z",
+     "iopub.status.busy": "2020-11-14T07:16:32.239126Z",
+     "iopub.status.idle": "2020-11-14T07:16:32.241889Z",
+     "shell.execute_reply": "2020-11-14T07:16:32.242418Z"
     },
     "papermill": {
-     "duration": 0.087011,
-     "end_time": "2020-11-13T16:26:54.023941",
+     "duration": 0.102889,
+     "end_time": "2020-11-14T07:16:32.242552",
      "exception": false,
-     "start_time": "2020-11-13T16:26:53.936930",
+     "start_time": "2020-11-14T07:16:32.139663",
      "status": "completed"
     },
     "tags": []
@@ -458,16 +460,16 @@
    "execution_count": 16,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-13T16:26:54.138998Z",
-     "iopub.status.busy": "2020-11-13T16:26:54.123615Z",
-     "iopub.status.idle": "2020-11-13T16:26:54.250654Z",
-     "shell.execute_reply": "2020-11-13T16:26:54.250104Z"
+     "iopub.execute_input": "2020-11-14T07:16:32.376688Z",
+     "iopub.status.busy": "2020-11-14T07:16:32.371527Z",
+     "iopub.status.idle": "2020-11-14T07:16:32.506823Z",
+     "shell.execute_reply": "2020-11-14T07:16:32.506213Z"
     },
     "papermill": {
-     "duration": 0.183347,
-     "end_time": "2020-11-13T16:26:54.250764",
+     "duration": 0.208352,
+     "end_time": "2020-11-14T07:16:32.506945",
      "exception": false,
-     "start_time": "2020-11-13T16:26:54.067417",
+     "start_time": "2020-11-14T07:16:32.298593",
      "status": "completed"
     },
     "tags": []
@@ -484,16 +486,16 @@
    "execution_count": 17,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-13T16:26:54.352226Z",
-     "iopub.status.busy": "2020-11-13T16:26:54.347127Z",
-     "iopub.status.idle": "2020-11-13T16:26:54.371780Z",
-     "shell.execute_reply": "2020-11-13T16:26:54.371144Z"
+     "iopub.execute_input": "2020-11-14T07:16:32.645719Z",
+     "iopub.status.busy": "2020-11-14T07:16:32.633218Z",
+     "iopub.status.idle": "2020-11-14T07:16:32.648478Z",
+     "shell.execute_reply": "2020-11-14T07:16:32.648973Z"
     },
     "papermill": {
-     "duration": 0.076233,
-     "end_time": "2020-11-13T16:26:54.371897",
+     "duration": 0.087068,
+     "end_time": "2020-11-14T07:16:32.649110",
      "exception": false,
-     "start_time": "2020-11-13T16:26:54.295664",
+     "start_time": "2020-11-14T07:16:32.562042",
      "status": "completed"
     },
     "tags": []
@@ -507,10 +509,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.043958,
-     "end_time": "2020-11-13T16:26:54.463859",
+     "duration": 0.053578,
+     "end_time": "2020-11-14T07:16:32.757812",
      "exception": false,
-     "start_time": "2020-11-13T16:26:54.419901",
+     "start_time": "2020-11-14T07:16:32.704234",
      "status": "completed"
     },
     "tags": []
@@ -521,24 +523,24 @@
   },
   {
    "attachments": {
-    "wine_review_pipeline.png": {
-     "image/png": "iVBORw0KGgoAAAANSUhEUgAAA1oAAAF2CAYAAAB3U+n6AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAhdEVYdENyZWF0aW9uIFRpbWUAMjAyMDoxMToxMyAxNzoxMzoyNWu7WPYAAEh2SURBVHhe7d0JfFX1nf//z81KSELIBoFAIOyroiiKIoKCWlfQsa3jtFPb2ulMp63Vzq8dH/1V2xn9t79OrdX++2trqc50HLu4S10pIqK4oSDIGnZCQhZCNrInv/s5OV84HG5ClnP319PH8Z7zPcu94d577n3f73J8XX4CAAAAAPBMgn0LAAAAAPAIQQsAAAAAPEbQAgAAAACPEbQAAAAAwGMELQAAAADwGEELAAAAADxG0AIAAAAAjxG0AAAAAMBjBC0AAAAA8BhBCwAAAAA8RtACAAAAAI8RtAAAAADAYwQtAAAAAPAYQQsAAAAAPEbQAgAAAACPEbQAAAAAwGMELQAAAADwGEELAAAAADxG0AIAAAAAjxG0AAAAAMBjBC0AAAAA8BhBCwAAAAA8RtACAAAAAI8RtAAAAADAYwQtAAAAAPAYQQsAAAAAPEbQAgAAAACPEbQAAAAAwGMELQAAAADwGEELAAAAADxG0AIAAAAAj/m6/Oz5mNDR2SnlRxuktKpOjvhv9x6pkNqGJmltb5aj9a3S6f9rm1papP54u7V9fWOHtHeIJCWKZKb7/+eXnpYo6UOGSIJPJCczRVKShkhWRpoU5efJ6LxhUpCTIYX+28QEcioAAACA00Vt0Gr1p6Ot+ypk2/4KOVBVLQcrjsqRmkapPtYuGRkdMmRIoySk1EhSSq0kprRY+yQlN0tCQof4/FNysl2W6i/zdfgDWKK0twyxytraUqWrM1G6uhKkrTXNKutoTZX21iyR9mxpPp4udQ2Jkj0sUUblZsiYvBwZNyJXpo8bITPGj/AHs+7ABgAAACA+RU3Qamppk817j8jG3Yfko5IDsvdwgz9QNUvy0FJJHlIryamNkpLWIKlDGsTnC/6f1NXlk9aWdGlpypC2Zp2ypL1ptNTWDpGikekyd+o4mTt5rMzwh6+MtBR7LwAAAADxIKKDljb/W/nOJ/Lutr1SVt0kw7LqJWnoIUnLrJT0zGpJSOxu/hdJOjuS5HhDthyvGykdTYVSUzNMRmSnysWzJsiVc6dL8ahse0sAAAAAsSriglZDU6us/mi3P2BtkrKj9TIsv0Qysg9KWnpNSGqqvKY1X82NWdJwbKw0VE2W7MwMueaCs2Tp3EmSld7dVBEAAABAbImYoLVu83558b0tsqmkXIbnlktazk7JHH7EXhs7GuvypKF6itRWFcrM4nx/6JotC2aPY2ANAAAAIIaEPWhpwHrkxbelqb1KhuZtlqycwxHZJNBrOvhGbdVoaayeJQntOfL15QutwAUAAAAg+oUtaG0sKbMC1uGaCskpfE+G5ZTZa+JPQ22+VB+YL5lDsuVbNy2SOZNG2WsAAAAARKOQBy0d4OLBJ9+QbYfKJHfMh5Kdvz8q+14FQ03lWKkpPU/G5OVZgWtSYa69BgAAAEA0CWnQem/7IbnnsVckr3Cz5IzeZV2/CqfSwTOqSqfIsfKz5bu3XE5zQgAAACAKhSxo/fH1jfL7196XUZPXSkZWpV2KnjTW58ih7YvkM4vOlb+/8jy7FAAAAEA0CHrQ6ujslP/zh9Xyzs4dUjjldeuCwuibtrYh/rC1WOaMnyp337pUUpIS7TUAAAAAIlnQg9a/rlgpu458IoWT34yL0QS9phdAPlwyXwoypsmDX1vOMPAAAABAFAjqt/ZfrXxbdpTulDFT1xCyBkj/3QqnrJOyut3y4FNr7VIAAAAAkSxoNVo7DlbJXb9+Wopnr5Sk5Fa7NHh+duPL9typvvX0VfZcdNOarX2br5Xv/931MnfKaLsUAAAAQCQKWo3W//nja5I39oOQhCxjS9k7VrAy0/6j260AduPZ/2Rv0Tf/fu2f5I5FD9pLkUFrtvLGvSMPPPlXq98bAAAAgMgVlKC1ee8RqW44Ktn5B+yS8HhwzR1W2Lpk4vUyIW+WXRq9hmWXS3PHUdmw87BdAgAAACASBaXp4I//+Ff5uHyljBi7zS4JPq250hqtFevvtUu6acD6+sL/OGXdl+bfK7NGXWjNKw1jGsoWTrxBlp/9j3bpSab5odZyjcuZZs2rQPcXbNXlxTIh/Qa59+9jo0kkAAAAEIuCUqP1yd5yycg+Yi+F156qLdLYWicjM8dayxqyMlOHn2he+PDab1vhSZsXrt39nFWm22v4MtsoDVn1LcdOlD2z6f9aYU3DWShlDK+Uzf5/XwAAAACRKyhBq6q2RVJSI/N6WVoDpbVXhgli2UNH2CWB6T7O2isNZSovo9C6DZWU1EapqeuwlwAAAABEoqANhuHz2TMR4nhrvT3XXTulTQ3NlJ4yzKrlOpO7r1hxyn7qTAHNaz5fUC97BgAAAMADQQla2Zkp0to81F4KL+2jpUFKm/0pDUvaVNA0AdRJa7TOREciHJqSecp+4dDSnCHZwxLtJQAAAACRKChBa9b4AmmsC21NT08WT/4b6/b1XU9atxqWdBCL3jhrvwwNax8eXGMvhU/DsXyZOjbfXgIAAAAQiYIStD41b6Y01Uyxl8JHmwjqgBVv7n7e6oulNEQV586w5pVuoyHKLS/j1IsCa63XtJFz7aXumrFwaD42Ra6eF/1D1QMAAACxLCjDu6vP/+h/JCn3r5KVW2qXBJfpM+Wk4eh7Kz9tL53k3FZHF9RaLg1gZpAMMyS8MsdwlimtFdPAtrd6a8iGeG+ozZe6g1fI/3zvVklMCFr3OgAAAACDFLSgpRct/t6jz8r42S9IQmK7XYqB6uxIkgNbr5H/dfM1Mn9GkV0KAAAAIBIFrVpkdvFIWXz2dDm8a5F0dUXYEIRRqGzPxTJ3wkRCFgAAABAFgtr+7OvLF0hh1kQp3blAOrsYKW8gNKSW7blQslMmyr/eusQuBQAAABDJgtZ00GhqaZP7Hn9VthwskTHTXpfk5GZ7Dc6kvS3FqhEszpsk/3bbpyQtNdleAwAAACCSBT1oGSteeleeWrtJxk5fI0Mzjtql6ElzY5aU7lwkV807W/7hmgsZ/AIAAACIIiELWmrVhyXy86fekOzRH0pOwR7x+UJ211HlaMV4qdh3vnzjpkvkU+eHf5h8AAAAAP0T0qCldhyskoeeeUMOVlZIXtEHIRv+PRrU1RRIzaF5kjkkW77z2ctlxrjIuOgzAAAAgP4JedAy1m3eL4+8+LY0tlZI9pgPJCOr0l4Tf5oahkv1wfmS0JEj/3TDArn07GJ7DQAAAIBoFLagZbz8/i559OV3JCG1QobmbJHM7PK4aFKoownWHxspjdWzpKkuV/7RH7CWzp1IXywAAAAgBoQ9aKmOzk55Y9M+eWbdh7L78DEZnr9PhuWVSFrGMXuL2KGDXNRWTZT6oxNkbF6WXHPBWbL0vEmSksTw9wAAAECsiIig5VR5rFFe/WCHvLD+E2npaJCM3B2SkVMqQ9Lq7S2iT2tzutQdLZTGo9MlSdLl2gtnyhXnTZWCnAx7CwAAYlNtY7P8ec1m2bz7sOw6fEyaW9vtNbFrSEqSTCjIklkTRslNC2dJ/vB0ew2AeBJxQctJB854fv3HsmHHIWloapGM4bWSPPSADB1WJWnpNRHbxFD7XDXWjZD246Ol/liupKYky7zpY+XqebNkdvFIeysAAGLbmo175ME/r5PibJ+MyvBJQUaCJCf67LWxq62jSyobO6W0vkv21HTJV5fNl6vOn2yvBRAvIjpoOR2tb5KNJWXyUckB2bS7VI7UNMvw4fWSMKRMUofWSMqQBkn1T0nJrfYewacXFG5pzrBqrNqas6SjaYzU1GRKTmaqzJk8Ws6fMt4KVvySBQCINxqy/u8z6+SSokTJHRq//Y+PNXfK2v2d8pklc2XZghl2KYB4EDVBy62hqdUKXp/sK5eDlZVyqKpWKmpapKOzS9LTWyU5tVYk+aikpjaKL7FDUvy3KjGxTRKT2qz5lCHdZU4amlRnR5K0t6dY822taf7lRP+6DOlqy5W2lixpOp4iPp9P8rJSpTA/S8aPyJeZ4wtkzqRRkpHWvR8AAPFImwv+/f1/kiUT4jtkGfUtXfLirnb51V030m0AiCNRG7R6ogGstKpOyo/Wy6HKGtlzpEKaWpqlpr5NOrs6pK6xVVrbOqXL/9+xuk5rn73rn5fi+ddb88OHJYjP/19KcoIMS0+RBF+iZGcmS1rqEBmXny9j8rOlMG+YdaLMSh9i7QMAAE767V/el0+2bZd5hUl2CTaVd8iY8RPln5fPt0sAxLqYC1oDoTVT/DMAAOCNbz70nBSm1MvYLEbUNcobOmVX/VD55Z3L7RIAsY76fAAA4CkdXVAHvsBJuWk+2VdRZy8BiAecBQEAgKd0CPd4GF2wP/TfIx6GtgdwEkELAAAAADxG0AIAAAAAjxG0AAAAAMBjBC0AAAAA8BhBCwAAxKyFCxfKLbfcIvn5+XYJAIQGQQsAAESMa6+91poCWbp0qdx44432EgBENoIWAACIWWvXrpUnnnhCKisr7RIACA2CFgAAAAB4zNflZ8/HLZ/PJ/wzAADgjcvuXCG3nz/UXuof02xw5cqV1q2TNh3MzMyUp59++sRyamqqlJWVyZQpU6wytWrVqhM1WHPnzrXWOcu0v9aSJUuseWPDhg2yc+dOa96s17JZs2ZZ96Gqqqrktddes+YH4pH3j8vqB75kLwGIddRoAQCAqKXBa9SoUVbzQJ3q6+vlkksusdeeTkOXhqjS0tIT+2jA0kCmk5Mub9myxdpGQ1deXt5p2wBATwhaAAAgarW0tJxS+6W1W1oD1dMogxq0NIxp3y1DQ5SWaWBz0gBmarn0Vu8rJyfHWgaAM6HpoB9NBxFqqz/aIxt3lcrWfUdk35E66eT1F9ES/OeIsfmZMq0oX86eXChL506UxAR+pwJ6Esqmg85lpUFKa51MU0CddzYd1FELNVS5mwA6j2WaDur+ehyjt8fWFzQdBOILQcuPoIVQOVBxTH70369L8/EGGTfcJ7lpPsn2T/pFHpFLg3BNU5ccbeqU0oYE8SUPlW9/dqFMKsy1twDgFKyg5V5H0AIQyfhJFggRDVl3PPyCjExplKUTk2RKbqLkDk0gZEUBfY70uZqcmySLxiVIUVqjfPuXf5GS0mp7CwBeqaurswJPICkpKdb6wWhtbT0xuIWTluk6APAKQQsIEa3JOnukzwpYiG7F2Ykyf2yC3O9/Tjs6O+1SAF4wfadM7ZGhyxqGnH2rBkL7cGmQcw5qsXDhQqtMa7AAwCsELSAEtE+WNheMlpClX0BuueWW0yZtWoNuRVmJkiYt8uI7fDEDvKaj/GntlfP8Y8oHS5sC6qTNCc2xCwsLraaFBC0AXqKPlh99tBBs//6fq6SzvsxqehYN3H0ajIF82XH3l4gl+2o65HjqCPm3L11hlwBQg+mjFcvoowXEF2q0gBDYdqBKRmZEf5NBE7DcTXrilfbb2nWoyl4CAAA4iaAFhEBZTaMMS42NQS/0Ip/al8F5jRodxcs0wdFJa7GUNjU0/SBMc0Rn80PnPjr1dN2bSJXpf04rapvsJQAAgJMIWgD6pby83LotKiqybjVkbdmyxart0kmDmAlXOnyyGRpZb3W9GVJZg5U2TTT7VVVVySWXXGKtAwAAiHYELQCDoteccfa9MkHsTLVTGq6c/b+OHj0acMhlAACAaETQAjAgesFPw9n8z9RmZWdnW7c90SDm3M80N4y25oMAAACBELQA9EtBQYF1W1NTcyIsabM/0wTQNBXsjYaqJUuWWM0MzX4MqwwAAGIJQQtAv+Tl5Vm1Wdrsz9Rabdy40boNRAOZmw6moQZ74VEAkWlISpK0dXDZFCf990hKiI1BkQD0DUELQJ9p7ZX2o1q5cqW1bELU9OnTrVtlmg66mZowZZodmm21Zsw0HQQQ/SYUZEllY6e9BFXd1CVFI4bZSwDiAUELQI+0eZ+zH5Vp6mdorZY2+SssLDyxjbsJoG6j+5ltFi5caG2jZRqutEzvh6aDQOyYUVwgpfXUaDkdqe+Qmf5/FwDxw9flZ8/HLZ/PJ/wzIJguu3OF3H7+UHsJseSR94/L6ge+ZC8BUJXHGuX2nzwlV05KlOFD+E23sbVLVu5sl4e+eb0UjRhulwKIdZz9AACAp/KHp8tXl82Xtfs7pb4lvn/I1JD15oFO+dsl5xCygDhD0AIAAJ676vzJ8pklc+XFXe2yqbxDyhs642aADP079e/dVNZm1WRds+Bs+fTi2fZaAPGCpoN+NB1EsNF0MHbRdBDoXfnRBnnyjc2ydW+57Kuok+bWdntN7NLRBXXgC+2TddOls6jJAuIUQcuPoIVgI2jFLoIWAAAIhKaDAAAAAOAxghYAAAAAeIygBQBALPL5mJhOnwCEDEELAIBYpf2PmZjMBCCkCFoAol5+fr7ccsstsnDhQrsEAAAgvAhaQITRsKChwTndeOON9loAAABEA4IWEKGeeOKJE5PSwIXAKisrrX+ntWvX2iUAAADhRdACosCWLVus27lz51q3AAAAiGxcsNiPCxYj2PpzwWJtOlhYWHiiJktpH6QlS5ZIaWmpVWuzdOlSSU1Nlbq6OmtbZbY3+xtVVVXy2muv2UvdNWMbNmyQcePGSV5enlXW0tIiTz/9tDWvrr32WqtM6TbO9bouMzPTmlfu4yt9fObYSu9v586d9tLptXOrVq2yaqUM53rzN6spU6acEjadx9V9nNtqc0t9bPrv1NPfqQLVFAbaridcsBgRS0eY47MNTrwmgJCiRguIAtnZ2dZtY2Ojdas07AwbNuyU5oUm4JgynXRZy500rGiYcO6rAcrJhBNdb0KHhpeUlJQT++mk2zn3dT8GDVGzZs2y1plBKzQcmfUajjRE6jplApJZr3+jrtNJH7dzX3PcnmjgdP6dGrqc/xbu+6qvr7emvoYsAACAnhC0gChggpHW4DitXLnSnusOMRpwTDNDQ4OMCU2Gs+ZH7d+/3wpuJuwovT9nTZU+Bg0qb775pl3STYOP2dc8BmftldZUmeAyZ84cK8g4/w7zOKZPn27duunf6KztcjpTINIQ5fw7ddnUxulj1b9H/3ajrKzslNo6AACAgSJoARFKa37MpAHBHSo0CDmZWi8NRM59nc0Ie6LhR5ljqNbWVnuuW3p6unXrDj3Ofc3+psxNg40GGefj08lJg4+GNS3Xv8XQ+9V/B20+qOucobCv9N9MH4PS4+myNqE0Ro0a1eNjBwAA6A/6aPnRRwvBNtg+Wm7a/E0DizN8mf5L7v5QbhpS3DVa7n1NU0BnjVlPj8u5r+rtMQQ6bk/M/Sl3Hy7TT0yDkvk3cP9d2ixQQ5OzVs79N+g2Jngp5/H6ij5aiFj0x4Ebr4mgOVBxTFau3y6bSw7L7rJj0t7Jv7NbUoJPxo/MklkTCmTZJTOlaMRwe03sImj5EbQQbKEIWlrDo32dNOA4m+a5BQpaGo40MJlAEygQubcxnOWqt8cQ6HGfSaDHq9zhsL9By+zf279zXxC0ELH4Ug03XhOe6+jslD+t/lj+sHqTzMxPkILMBMkZmiCJ/n9qnKrD/9I7erxTjjR0ytaqLrn50tnymcvPlsSE2G1gR9NBIARGZKVJXUtwP9w0/Giw0ADhbFanYcI5AITSsKGhw9B9dF9ngHIzwemCCy6wbpXej+6rTfp0X+djMHQbDT1KmwVqDZL78eh63c65rTLH0UFA3H9HQUGBdVtTU2Pd9pfZTwOac3IO7HEmja1d1nMLAIhPGrJefOtjuW5qsswuSJL8dEJWT/TfRf99Zo1MkuunJsmqd7fIf77c8w/DsYAaLT9qtBBs//6fq8TXUCYTcpLskp45a1160lvNkK5zDn6hwcdZM2VqfnQ0Pz2Gcm/TWxM/d3O7QLVNpmmf4WxKqGFKa72cnOvN3284j9/bcc3f1dcaLaX7OI+hAu3XkwO1HVKXmCf33X6VXQJEEGov4MZrwlPaXPDrDz5nhaz0FNJVf7V2iDy/o01+/NVrZFJhrl0aWwhafgQtBNvL7++Sp157Ry4rPnPQCjZ3IIlXPYVVLdcg2Zd+ZOsPdcilF5wjNy2caZcAEYQv1XDjNeGpXz73jhzas8uqycLAbK9sl7TcMfLdWxfbJbGFpoNACCydO1F8yUNlz9F2uwThZkYg1Bo2Q+e1NlAvBH0mh+s65GhLslx30TS7BAAQT3TgC+2ThYEbkZ4gW/dX2EuxhxotP2q0EAolpdVy1/+/Ui4qSpSirES7NPSo0TrJ3cxSaTNC0x+tJxqy3jrUJf/+5StlxrgRdikQYcJYe6EDACGwsA6eQ42Wp6749u/k8+em0SdrkGJ5UCmClh9BC6GiYeu+36+WjIRWGZ3RJblDEyQzlTN0NNCBL6qbOqW0XqyarLs/t5iQhcgW5qA1esZ8ewnG4a3rCVoxpD8jCqNnBK0YR9BCKOlQsC+8vV3e33ZAdh8+KhW1TfYaRDIdXXDi6Bw5d+pYq7lgSlL4aiWBPiFoRRyCVmwhaHmDoBXjCFoAgJhD0Io4BK3YQtDyRiwHLXrwAQAAAIDHCFqRRH9pYmJiYmLyfgIAIMQIWpFGq/SZmJiYmLybACAK6UX6dQqFuXPnWqMSOy95gsEjaAEAAAAhomFGQ417Wrhwob0FYgVBCwAAAAgxvW7jE088YU06X1hYaNUsIXYQtAAAAIAw0gvlt7S0SE5Ojl2CWEDQAgAAAKKANi90NjdcunSpvaablmmtmPbtMtsE6uflXH/jjTfapaeaMmXKiW0CbafH0PvXqbfjxDOCFgAAABBGGo5SU1Nl//79dsnpNNDk5eWdaG6oky67w5YGpLKyMmv9qlWrJDMz85T+X7q9lplj6H3qPk76eHTS/c12ra2tp4UpvX+l659++mlrHicRtAAAAIAQc9YY6Xx9fb3VVysQHUBDQ82WLVvskm6lpaUnwo6hZdoUUVVWVlrHHTZsmLWsdHvdxtBt3fc7btw4axvd39BtNAw6Q5k2d3zttdfsJbgRtAAAAIAQcw6GoVNKSooVugLJzs62brWWyYQznXQAjTPRMKTHViYklZeXW7c90UClx3bel963m9ZyoWcELQAAACDMTG1VoEBjaO2TM5yZKRi0RivQffVU64bTEbQAAACACFZTU2Pdat+qwejpOOnp6fZcN60F01otDA5BCwAAAAizWbNmWbemf5WT6WulTf+0v5ahtV/uwTB64zyOocdwN0Gsqqqy+nI5a9f0fhlZsH8IWgAAAECIadhx9oFS2jSvJytXrrQC0JIlS07sM2rUqH4PRqHH0Ror5zHc4W7t2rVWE0HnY9T7ZWTB/vF1+dnzccvn80lE/DP4H4f/gdgLAABPxOu5NYx/92V3rpDRM+bbSzAOb10vqx/4kr0UBnzP8JS+zm8/f6i9hIF65P3j4X1fBBE1WgAAAADgMYIWAAAAAHiMoAUAAAAAHiNoAQAAAIDHCFoAAAAA4DGCFgAAANBPSQk+6WQUR/SCoAUAAAD00/iRWVLTRNAajLqWLhmVnW4vxR6CFgAAANBPsyYUSEVDp72EgTjS0CEzxuXbS7GHoAUAAAD009UXTpNNRzqluZ1arYFo6+iSLZU+WX7pbLsk9hC0AAAAgH6aVJgryy6ZKesOdEprh12IPtGQ9fahLll07iSZMW6EXRp7CFoAAADAAHz+ynNlwbnT5IWd7bK9sl2qj3eKP0MgAB045Kj/32dXdbus3NUpZ02fKP9w3Tx7bWzydfnZ83HL5/NJRPwz+B+H/4HYCwAAT8TruTWMf/dld66Q0TPm20veaag8JM/dfaW91G3BV34i486/2pp/7u6r/NsclMmLPivzbv3fVpmx+sGvWLeX3fEb6/a9x/9Ndq35g2Tkj5Ub7n/ZKjO2vrxCPnrqAbn1kU/sEm8c3rpeVj/wJXspDPieETQlpdXy5JqPZev+CjlU1WCXwinB//obm58pU8fmyfULZsZ0TZZB0PIjaAFADIvXc2sY/+5gBC0TfpzBSmm4mrP8G1aZCVrqhvtf8YeoMda86iloKfcxCVoAvEDTQQAAMGBbtmyR9vZ2eyk4tCZLg885N915SiBSWhvlLNPaLK2leu/xH9olPdPtdPt1v/kXuwQAvEPQAgAAA/bTn/5Upk+fLo899ljQAtfWVx+1bmdc1bfaIK3hKvvkLaks+dAu6dmMK26zbrUWCwC8RNACAACDUlJSIrfddtuJwNXV6e21hbQ5oNY+9ZXWcOn2b//ubrukZ9q8UGu1tMZMa84AwCsELQAAIsC+fftE+wx7NvmPGbDc40mDlWEC18fPPSQdbS126eDVVxyQzBFF9lLfXPTF+62Atv/9F+2SnpmBM0zNWbDsXf98wH/DkE3+xxCwPAjTvffe2/1HA3GMoAUAQIQYP368NTiTJ5P/eAHLPZ6+8IUvdD94v0mTJsmjjz4qZ93wDUlMTrVLwyN/0rkyaubFfe5/pf2/dHCMvjQ3HKji+dcH/DcM2eR/DAHLPZ7uueee7j8YiHMELQAAMCgmYG3bts0KXr4Eb79eaGDSPlf9Ne/W71u3fel/pf2/tLnh5pW/sksAYHAIWgAAYMDuuuuuEwErKSnJLvXWyClzrdu+NAN0cva/6gsziEb59nftEgAYOIIWAAAYsFmzZgUtYBk6uIUZht0dtvT6WL0FMNP/qi81Yno/A609w0kZGRlSWlpqLwHxi6AFAAAingYmvbCwhq3Hb595Ypp48bLTrq3lpvv1lWluiIHLy8sL+rXVgGjg69Jei3FOR8eJiH8G/+PwPxB7AQDgiSg5t+qog4sXL5a9e/faJYMUxr/7sjtXyOgZ8+0lGIe3rpfVD/TtWmBBEaLXhI5E+cYbb1j99mKNvrYRHmF97wwQQcuPoAUAMYygFXIErcAIWtGP13Z4hP29M0A0HQQAAAAAjxG0AAAAAMBjBC0AAAAA8Bh9tPyisY8WnTEjQzDaC/PchofXzyXPo7cG9fzQRyvk6McSGH20oh+v7fCI1j5aBC2/aA1avNHDK1hvep7b0AvGc8nz6J1BPz8ErZDj9R9YvAStJ598UlasWCEvvfSSXRI7eG2HR7QGLZoOAgAAwDN6Ha3m5mZ7CYhfBC0AAAAA8BhBCwAAAAA8RtACAAAAAI8RtAAAAADAYwQtAAAAAPAYQQsAAAAAPEbQAgAAgGeGDBkiVVVV9hIQvwhaAAAA8ExBQYE0NDTYS0D8ImgBAAAAgMcIWgAAAADgMYIWAAAAEKWeu/sqWf3gV+wlb1SWfCiP3z7TusXAEbQAAACACKZhSoOPmRoqD9lrEMkIWgAAAECE0pCVOaJIbn3kE2u64f5X5K8/+7K9VvzLL8tld/zGXkIkIWgBAAAAEUhrrhoqD8rEi5fZJSIZ+WOscIXIR9ACAACAZ/Q6WseOHbOX4IUjOzfYc6fT/lnOPlo6/97j/yZbX15xSnNDN93Oud5MvTVL7M+2IGgBAADAQ3odLYKWN7T2avKiz8quNX/oV7DR7RuqD59obpiRP/aUMKZBrL7iwIn159x0p1Xeve0Ya95J71fvf8FXfnLKPs/dfSVhqxcELSBO7H//xVN+hQo0cbIEACCyzLv1f8sV3/m9Na/Bpi+f16NmXmztZ0xeeLOUffKWvSTWvJYZRXOvtG57GmVw66uPWsccd/7VdonIjKu+ZN0e2PCKdYvTEbSAOKEnR/MrVPcvVmOtX8lOLTv9V6z+0A67+ivZmeiHhDZpAAAAZ5Y/6Vzrc1oHwlD9rUlKzx1l3Zp9NDTtWvtna16ZsKT3E4j2E9Nw5vxxVif0jqAFAAAARIHugTC6Q9Fga5I0PJnA9NFTD5w4bk80nDl/nDWTqdnC6QhaAE7hvlaHaUZgOtU6mxWYsv3vv2zd6knbtCPXyc00X1R6Utd5vT8jUPNGAABwOlNLNRD6Wa3NEZ2BqbdWLdoKRvt0oX8IWgBO0GCjbbbNSVc7vb76489Z4Up/sdJfs97+3d3Wttr8QMOSbjPu/Kvsk/SpzRHdTPNFpZ1odd4MUauhbd1v/uWUE78eSx8TfccAAPFIPxudg1io9x7/oXXr7C/VX/p5rZ/vzh82depJ8QXXWD+mursH6I+lfEb3zNflZ8/HLZ/PJxHxz+B/HP4HYi/07rI7V8joGfPtJYTD4a3rZfUD3leXh+q51ZOjs7Osnsy1vbb72hzO7fRkqu3CNSSVb3/XWu+8SKL7mD3Rk7kew9ncIFCZ6qncS8F4LnmPemfQz08/zq3htG/fPlm8eLHs3bvXLhmkMP7d+vpHYMH43OizEL4mIua7lcfCcW7XcKM1UIaGJOdntQli5vPYvay0xYj+mKnNA7XmSrcpmHbBKZ+tej/aD0uPrT+wahDTHz9Nvy3zHcDJuT6YgvWdK9gIWn4ELQxErAUt94ncSWuWnIFMa7KUu9ZqoEHLnLy7a8dO/YWur8ccDIJWZCNoDVCU/N0IoRC+JpKTk6W+vt66plYsiYVzuzt0Gabc/dkeCaI1aNF0EMAJ+iuZabbnnJwhR6/LYfQ0DCwAIL6NGTNGysvL7SVEkqHZBdZt9b6PrVtj4zMPWT9swjsELQCWjNzRVvvr3miwMh1o9WRs+msZmSOK7LneaaBzMr+oNVaXWbdO+pj0sQEAgMHTpn7agkRrr7SFiZn0c93Z3BCDR9BCRNEmZPpm1+prhJa5WKG7060um5orDVbajFBP0vNu/b4VgrQpoZPzgoi9MX28DD2uNkl0dqo1jyWY/bPihRnR0fnv6+Z+/5l9qLkEgNjivramu/UKvEHQikP6pUm/PLmn3r6A9YV+4Q50XOeEyKW1SnqidV+QcOLFy6xgpX24NFiZE7Fur/2sNByZL+ImfOl+2reqJxd98f4T92PClB5Xj2eueq+TDiWrjyme6L+z+fvN5A6/AAAg8jEYhl88DYahX9j0C657lBj9oqyjy/TnS+2ZBinQL4j9HS1Ow15PgyJEmmgfDAMnRdJgGM5Rnwx9L7lHmeov08nZ3fnZKVLffwyGMUAMhgG3EL4miouL5fXXX5fx48fbJbGBz+jwYDAMRDytcer+AvfKaUNx6nK81RwA0UKDj9YU0oQPAIDoQdCKcCtXrpQHH3xQmpub7ZKB0yZe2g+mp1+z3dxNAfWXdmWaHuoXPx0YwazvK7O9mc7UH0trzpzH7+lxGeaYWntntnE3vXI3nwzHF9iSkhJ7DtEu2M+lGSHqeE33CF7u12+gZprO139PzTjd76Wm2gp7TTdzP+b9YZZNXy4z6XGc3I/PTO73arQ7dOiQJ+dmAEBsImhFuKqqKvnWt75lVcEPJnCZL0ojp8y1bs9EvxDpxWu1lstMGqq03NR+aVMmDW5m/ZmYL2fOfbQJozZncn9RM/QLogY6c/zeHpeTHlP7Ful6rcHTmjxzH/o4tJmk1hKYY7hHzwuF++67T8455xx59tln7RJEq2A/lyZgaeDS97K+Xs1rVyflfA/ovL7mzfo5y79hvSec9McI/fFF34O6jb5P9H3RF9q8ULfX/fR95OynF+j9pbQZcax1tF61atWgz81ArEpKSpL29nZ7CYhP9NHy0z5a99xzj70URj/4gfgfiL3QbdOmTad8eSsoKJDvfOc78uyeITLmrIV26ZnplyD3Fb41eOgXJMP0ATH9NNz9uMz25otTf/tomS9/7n4mznJz3/olbfdbz1qDIZjt+/q43PerTI2WDlvqvI/B9EMZbHvh2267TR577DFrfs6cOdZrcNmyZbT/DoNgPJcPra32pI+Web32Nuyu7qM/SJj1gd4D7j5azveE4X5vuM8bgc4jynl/5n7M+1G5H19/RWofLX3O9blX5tz81a9+Vd555x1Zs2aNVd4ftbW11vmePloImhC+JrS/oZ4LFy1aZJfEBj6jw4M+WlEsIkJWHx07dkz2798v7S3H7ZL+Mb+MK/1SZH5x1i9J+kVImeZD+oVKv0CZyRnKBkKPH+g6S4Gu36Rf1NyhbDCPS0Okhrbu+TFWrZreh+6vXy4HYu/65/2fWb4BT+aLudq4caMsX75cPvWpT0lne5tdilAJxnO56ZkHpaOtxS7tH30/mNe3Bh99fzpDioYZs14nrdU1r29Ts5Q/6Rzrtif6/iqYdoG9NDj6/jIXss4df5Z1q4/R0Mc3mPsa7PPj/2oZuHyQkwlZSi/Mqq0Ppk+fLr/4xS/kBz/4Qb8nrRmrq6uzjwhEv5///OdctNgD+oOynusRfajRiiT+D273L03mF9MhQ4ZYv5TqL6b6y+lAflHRN6kGjEA1UM5aoZ5+tXbrb41WoF/QlfO+nb+oaxByjrTW18flvl/VU22aPiYtd95PX3lZC+L8Nfzqux/n17IQC8Zz2d9aZ6On16ph3i/O94Fzn57eJ+4arUDvk4HWaDnPBeYYTj2dd/oqGmq03OfogWDUQQRdCF8T+lrWml39Mfvee++1S6NfOGq03C134hE1WgiKjIwMueOOO6wP3p/97GcD/gBX+mVHf1k+Uw1OWtYI69ZZ+xVIoNqp3jhrlZz0l3Bd56ZfCPWXff0Sqfr6uPpDQ59+adT70S+RoabPpz6v+vzq86xf1hCd3M9lQlKyvcZb+n7RUNPTjw09vU8aq8vsuW7OWijDPRjGQBzY8Ir1+ExtuU6DCVmRTt+zXp2jgVixZcsW+eCDD6z5X//61/RhRNwiaEW4v/mbv/Hsw1u/7OiXK/212R0qnF+49Ndu/aKkv347Q5n+Im5Cj6G/ovdV8QXXWIFGf5kx9Jga/rSzvps+Dv1lXdfrPv15XL1xb19Z8pF1a76ghsrXvvY1AlaMCOVzqU1t9X1n3gPmPWQ43yeGbuNuYjt54c3WfuZcoMfT2qrBSs8dZT0+rTFzTs73faxYsGABAQtw0UG8tPl0Q0ODtaxNB//wh5PnqGgRTSMD6zneeb41LYj0vB7o/KvnfS0353+zbCb3SLV6PP3epFOg9egZQSvOaNMiDS/6hcr5ptIvXM4qaa3p0RowDWVmGx2cwvnL9Lxbv28FJ13Xlzed/gKvtVT6hc8cU78Mao1ST4NSaLk2b9J99ETQl8d1JnpMZx8Y0wxLv6CG0nnnnUfAihGhfC61qZ8GKfMe2PjMQ9Z7xEnfJ/qjivM9oq9xJz2OvpfMuUCP50WzFDMUvbNGy7zv9ctALJk0aRIBC3DRUOUebVD7akWbpUuXWoFR+91GMj2v6jneec7VH7ucP1DraM1Oe9/9i/UZod/LdH/9HNDztNlfWyy5v9eZH/R0fX+7WsQz+mhFkn60nWbUm/ALVnvhgTy3+quVflE29ATKibDvgvFcxut71Nlfy0nLtRbN2SesryK1j5bX6KOFoAvha0KvM7du3Tp54403rJE4teY3mkYg1Es36HtS6YjA2tdMR5WNhj5aWgOl3wP0PKxByvyobZqc649rpo9uoHOz/rDt7I+rx3OOAh0O0dpHi6AVSQhaUSVSgpYJWc6BDfTEemTnhn7V9MUzgpZ3An0gB/qg7w+C1gCF8e/W1z8CC+uXxTC8JrR2S2uFtM/5tGnTrIExdJTNaKRha23d2IgLWma9k/7gZQYf02BlBiUyIco5MFJPnEFLmeOFA0ELg0fQiiqRErTMl1hz0kT/EbS8pb+QavNcp8G8PglaAxTmoMVn1OnC/mUxBK8JvQyNjjb47rvvWjVZOmnYOnjwYFQ1tXXWaIX7Wpe9BS3tN6XN+pznWHcwMtvo/jqv52dnCHOPQOtG0Bo4+mgBMaJ638f2XGCmE6uZ9MTtZDrNOtfrPuYEa9ZrsHPS9WYbQ/d1HkuP42SOo/uZbdzHUO7HbDruGs51OuljRPhpbZZ+oDsnfgQA4sOTTz5p9W360Y9+ZAUuHXHws5/9bFT2Z9SA9cwzz8hHH31khaxIpKFJa6t6O8fOuKL7MhT6uauBa+LFJ/8WbWLoHoEW3iFoAVFOB/fQE6XWark7rxoaYvRkbL706i9f+uuYM2xp80M9WZttyre/e6Lza39oONKOt+Y4Oulx3GFLH6+e7HW9Ph7TedewjmP/Ame2eft3d1vrTOjTgV3Mev1FTv8GwhYAhM+Xv/xl65pyTt/85jftuejx+9//PqIDlqGf/87Pav0cdY8IrSHMORqtcwAyMwKt80dU/Rzt6fsE+oegBcQArUHQoGFGU3SeILUWSE+6OkqkoSddDVVmJCJzgjW/eiltIqAn5v7Qk7OesC/64v12STd9bM4PAqVl5mRvPgQ03ClzHA1Shm5j+v1sffVRa3vnh4Vp9qDXcQIAhM/DDz9s9cdSehkEHZk12ujjjjTOFhw66We39rvSsGXK9HNUP9/dTC2We51+dupnrYYwcwz90TKcA1/EEoIWECP0ZKk1O3rC1MBlwpa5cK2eOM1JVCdn8NGBM/RE3VvTg74wF7x1Xz7A3Uk3EL1/c0FrcxwzVLib/n2BrtUEAAi/pKQkq6mg3t511112KQbKfL67J/Njo7O5tv5IquHL3Z/KfJ7qNU3d9DjO4+rkpMcKZ/+saEbQAmKMnjBN2HL2adKmd+4TabB+sdKRitz3pZOXtEYr0H301qEXABA6f/7zn+Xaa6+1lxBOm1f+yvpBcyAjv2LgCFpADEvLGnHiVyxTSxRIRu5oK5i5mRomZWq7GqvLrNtA9P6UqUUbqDMdx1n7BQCITDqYhNZqIby0Ob62AtH+WAgtghYQ5XSgC+cgEkrbWmuNj4Yj/fVKg4k253PSfcx+RXO7L3bsHLDCDKDhpMd0XmFet3F2ujV9rfT+nYNSaDty92AYvXEex3B2ztWmD/rY3MfU9c77BQCEhw7zjsign6m0+AgPghYQ5bTdtIYfZ18l7ezqbE+tTQQ1uDi30eFczUlXT8La3E/7bZn12nFW93HSY2rAMdsUTLvgtI61uo2WOfuE7X7r2X5fPFmP43zMejwzyIaGR20K6Xy8Oul6/VsAAOFF0AK4YHFk4YLFUSVSLlgcTObaVs7QFou4YHFk44LFA8QFiyNOPFyw2NAL/r7++usyfvx4uyQ28NoODy5YDAAAANiGDBlizwHxiaAFAAAAz+kQ70A8I2gB6JE2GYz1ZoMAAO9VVVXZc0D8ImgBAADAUw0NDfYcEL8IWgAAAIBH9FIjzhFxdXJfhgXxgaAFAAAAeEgvc6LXrtJJL5/y0VMP9Ot6kuGk16PUcKjXwMTgELQAAADgqTFjuKahodd+1OCl135EfCFoAQAAwDM6EEZSUpK9BJWRO9q61doiw9280LlOmxpqE0StVXKv15ox536VJR9a5crURjknJ91XJ93HuY05Rvf9XmnNr/vNv1jrzDU1dT+d123MfoazTCd97E7m7+npfmMVQQsAAACeYSCM0zVUH7ZuM/LHnAhDC77ykxPNC8+56U4r4DjDVkPlQdn4zEMnttF9NexozZgpu+H+V+Tt391tba+hRY+hTRXNeq1J0/ty0v11H7ON3verP/6cdd8zrvqSdUxlHp9z9OGyT96S8u3vnthX6WPSppG6nynPHFF02v3q3+O8X31ser+xjKAFAAAABInWSmm40UCjtr76qIyaebGMO/9qa1lpwFEHNnSHHOPyb/3WnuuurdLjaAAyNHzdcP/L1vzmlb+ywos2VTRmXHGbdevsb5WRP/bEPqqn++6JM3g5H5M+FmPerd+3bt39vJz3W3zBNdZtLNdqEbQAAAAAD2n4MM3jtAme1jKZQKM1O1ozZNabKRBneGmqrbBuh2YHvhB0fcWBU+5XJ9MM8Ew0fJlat97odk49PSbzuBury6zbQNKyRli3x2vKrdtYRNACAACAp4YPH27PxSfnqIM6OWuZlNZoOdebyYSxgXLfr5mctWcIHYIWAAAAPFNeXh73Qas3WiuktU/9daYaIO0XpbVlA6H7mQE7nLVoZ9LTYzJ9zdJzR1m38YqgBQAAAM80NzfbcwhE+yZpsNFBJJx0VD7nYBhuGoC0JkybIhq6vRnhb+LFy6wmiTrCn5O7WaLet3NUQPM4iuae2szwyM4N9lzPAj0m9deffdkKlPFek0bQAgAAAEJEmxHqCH3u/lQXffH+M9Ym6UAUGmzMPtoHS/dTGmrMxZGdxzWjCBoagOYs/8aJ9fo4dBvnfevgFubxuQOhmz4mM7qhmbR2zTnwRbzydfnZ8wg3n0+kj0/HZXeukNEz5ttLCIfDW9fL6gcG15Y6EJ7b0AvGc8nz6J1BPz/9OLeG0759+2Tx4sWyd+9eu2SQwvh38/oPLFifG30WotfEmjVr5Ac/+IG8/vrrdknsiPbXtoYmrfWKthAU9vfOAFGjBQAAAAAeI2gBAADAM4cOHZLx48fbS0D8oulgJOln00GEX7CaDiL0gtF0EN6h6eAARHnTwTM1cdIO/9oXxdCLwerQ2Ksf/Iq1X0+0f4v2KekeeODgieVAugca6B4gwBx/MOKl6eBjjz0mb7zxhjz66KN2SeyI9qaD0Spamw4StCJJlHwZAICoQtAKuWAHLROynB34NWDNvvarp1yvqLLkQ3n1x5+zBghwX8fIjLqmYSvQeqX3s2vtn61tCFp9R9CC1+ijBQAAEALl29+1aqKco6RprVSgsNSb7mOMlb3v/sUuOZWGuckLb7aXAKB/CFoAAGDASkpK7LnQ6q15YH9okNJhrN3XL9r//ovW7WBrsQDEL4IWAAAYsPvuu0/OOeccefbZZ+2S4NMmgkqv1+O+OGt/mSB1YMOp1xra+MxD1rWB0H/aDDYvL89eAuIXQQsAAAzKxo0bZfny5SELXNpE8NZHPrGa/ZmLsw4mcGmg0r5Yhvbt0n5ZM664zS5Bf6Wnp9tzQPwiaAEAECG0JsDn83kz+Y8XsNzjSQc+MEzg2vTMg9LR1mKXBo8OlKGBS/taaeAaaNgqvuAaK1iZ5oLaZ8vdB8wLe9c/H/DfMGST/zEELPd40osVAyBoAQAQEfS6QzoQsGeT/5gByz2evvCFL3T/AX4FBQXys5/9TGZf9zVJTE61S4NPB8LQYOSsleoPrSHT2rHdbz1r9dXSPlsTL15mr/VO8fzrA/4bhmzyP4aA5UGY7r333u4/GohjBC0AADAoJmDp0PR33HGHJCQl22tCK3NEkT3Xf3OWf8MaYGPrq49aoWvc+VfbawBgYAhaAABgwL72ta+dCFhDhgyxS4NHa5y0T5ZzlEBt8qchaTC1UCZYaW0WQ7oD8AJBCwAADNh5550XtICl/aY0VDmnptoK6wLDz9195Ymydb/5F6tssLVQZpTBorlXWrcAMBi+Lm1Ii8jgC99V/AEgZsXruTWMf/dld66Q0TPm20swDm9dL6sfCON1ufieMWi8tsMj7O+dAaJGCwAAAAA8RtACAAAAAI8RtAAAAADAYwQtAAAAAPAYQQsAAAAAPMaog5GE0YAAwHuMOhhyjMwWGKMORj99bUerveufl+L519tL0ScaRx0kaEUSToAA4D2CVsgRtAIjaCGcfP7nn6/9oUXTQQAAAADwGEELAAAAADxG0AIAAAAAjxG0AAAAAMBjBC0AAAAA8BhBCwAAAAA8RtACAAAAAI8RtAAAAADAYwQtAAAAAPAYQQsAAAAAPEbQAgAAAACPEbQAAAAAwGMELQAAAADwGEELAAAAADxG0AIAAAAAjxG0AAAAAMBjBC0AAAAA8BhBCwAAAAA8RtACAAAAAI8RtAAAAADAYwQtAAAAAPAYQQsAAAAAPObr8rPnEW4+nz0DAPBUPH7U6WdKmP7uy+5cYc/BbfUDX7LnwiCMrwmEn8///PO1P7QIWgAAxCK+VMON10RcI2iFHk0HAQAAAMBjBC0AAAAA8BhBCwAAAAA8RtACAAAAAI8RtAAAAADAYwQtAAAAAPAYQQsAAAAAPEbQAgAAAACPEbQAAAAAwGMELQAAAADwGEELAAAAADxG0AIAAAAAjxG0AAAAAMBjBC0AAAAA8BhBCwAAAAA8RtACAAAAAI8RtAAAAADAYwQtAAAAAPAYQQsAAAAAPObr8rPnAQBArPD57BnAga99ccvnPyfwtT+0CFoAAABAjCNohR5NBwEAAADAYwQtAAAAAPAYQQsAAAAAPEbQAgAAAACPEbQAAAAAwGMELQAAAADwGEELAAAAADxG0AIAAABi0MaNG6W4uNialJnXcgQfQQsAAACIQXPmzJHx48fLvn37rGW91WUtR/ARtAAAAIAYdc8999hz3dzLCB6CFgAAABCjFi1aZE3ueQQfQQsAAACIYaYWi9qs0PJ1+dnzAAAAACLQ0fomqTzWKOVH66Wq9rg0NLVIa3un1NQdF2lsFPF/pa9tapOm400inZ3S0dkllY0tVrnavO55mb3gemtefD7JT0+VxASfSEKCpA1Nk6y0ZKtc0tMle9hQSUnyl6cky8icDMkfni4FOZmSk5nWvT/6hKAFAAAAhFlpVZ0/RDVIZW2jHPGHqSNHaqSy4qiUHzsulU3tkiadUtDWKPmNx2Rk5WHJqDoiif5AlddQYx9BJKupXtJa/eHKVlBXbc+drjIzWzp83Y3bmlJSpTYt05pXNUOHSWtSsjTkjZSqvFFSnpEt5cnp0tCVIAVDkyQ/a6gUjMyRkSOzJS+rO4TlDx8qRSOG20eAImgBAAAAIaShqqS0WrbtOyI7dxyQHRX+gNTRJkXNtZJfWy0jjxyUkRWlku8PUQV1VZJfXyNpbScDVLho+CofliuVGTnW7ZERhVLln8qH50tpWpY0JCTLpLwMmTJlrEwvLpCpY/OkMG+YvXf8IWgBAAAAQVLb2Cyb9/gD1aEq2b19v2wtOyYp7a0ytfqQTNn9iUws2yMz/FNWU4O9R/RqSB0qO0aOl92jimXblLNlR94YaUhMkakjMmX6jGKZUjTCCl/aFDEeELQAAAAAjzS1tMnG3WXyzkcl8v6WfdLR4g9Vx8pkSskWmVhaEjOhqq9q0zJk66gJ/vA1QXZOnCk7csdIYmqKnD9rvFx4ziSZM3GUpKUm21vHFoIWAAAAMAhaa7V20z5Zu26T7DhSJ1Nry+Xij9bK+Xs+lsJjFfZWMMqH5cn7E86St869VLYOHyVTC7LkwgtmysKzxsdUbRdBCwAAAOgnDVfrNu+XNW/6w1V5rcw/uE0u+XCNzD2wNSL6U0UL7fe1ccxUeXPuYlk3brYU5Q+ThRfNksXnTIj6UQ4JWgAAAEAfbd1fIc+99qGs33bwRLiat3+LpLS32VtgoDoSEmR98dny5rmLZP3Y6TJ3SqHceMVcmV080t4iuhC0AAAAgF50dHbK6o/2yNMvvSe1VTWy7J2X5OqNr0tGy3F7C3hNB9ZYNfMiefai6yQxL0duvvoCWTp3oiT6w1i0IGgBAAAAAWjAem3Dbnn8+fWSf+SQ3PzXP8r8PR/baxEq742fJX9YfLNUjiqSW5ddHDWBi6AFAAAAuLyxaa/89sk3rYD1+Zf+S+Yc2mGvQbhoX67/Wvq3VuD6/I0L/IFrkr0mMhG0AAAAAFvlsUZ5+H9Wy4Fte+WOZ39JwIpAGrh+ef1XJGfKBLnjc0ukICfDXhNZCFoAAACA32vv7ZBf/2mtXPfBq3LLW88xwEUE04EznrrwWnli/nXyxWUXyXULZthrIgdBCwAAAHGttb1DHv6f12Xrux/L9/74gBRXl9prEOn0mlzf/7t/laJzZshdn7s8oi5+TNACAABA3Dpa3yTf/fmzUvTx+3LXs7/kGlhRSK/F9eD1X5Udcy6Un9yxPGKuv0XQAgAAQFxqammTf7z/j3L+26/I11b9t12KaPXU/GvlhaWfkQe+fVNEhC2CFgAAAOKOhqzv/sefZcqalwhZMcSErV9899OSkZZil4ZH9FzxCwAAAPDII0+tk4L33469kKV1KM891z3/jW90Lz/8cPfyQOkx1q+3FyLbTetXyoXv/1V++Yc1dkn4ELQAAAAQVzaWlMlb726Vr7/8qF0SJDt3docU5xQlgSWaffG1x2Xrh9tl/dYDdkl4ELQAAAAQV379+1fln156VDJajtslQbRrl4jP1z0tXChy4YXdASwUHnqo+36//nW74Ay05kvD4CWX2AU2Pcb8+fZC5NNh+fUaaL98fLVdEh4ELQAAAMSNrfsrpKmqRi7dtcEuCaE33xR5/nmRyZNPDzPwlF5oOqOmSt7bfsguCT2CFgAAAOLGK6s/lGVvv2AvhcEBuznbOed031ZVdfepMs0MnbVdus7Z7FD7XDmZGqie1muY03J3Hy3nPnofSu/3n/+5e37t2u51pq+XbuNu8qjLzuO4a+l0vZa5H2MIA+YNa5+VV9/YZC+FHkELAAAAcWP3/gqZXrbHXgqDoqLu248+6r5V118vsm1bdxO9KVO6yzSUvPXWyWaHv/iFyM9/fjJM6a0GIy032+j6M9HjvvPOyX30PjRQ6f3qsZQ2cdR1N9zQveymAUqbQJpj6JSTczK0GVpzd+WVJ7fRZpTPPGOvDL6p5fvkwOFqeyn0CFoAAACIG6WNbVJQ5woEoaLhSEOVBh1tRmhoAHGGGg0+1f6A4CzTflZadsst3ct6q8vO/lcaZnpjaqic/a30PnoKVIHo36AB6pvftAtsP/yhSG7uqbVq+vhMcFSvvNK9TYhqtfIbaqS8sdVeCj2CFgAAAOJGR1eXJHZ22kshoKHENJvTGietNXIPLKGBxGnEiO5AYvYzk5YZelwNaP2hx3XfV3/p/SpnjZwyy2Z9IObxmmaTQZbY2WHPhQdBCwAAAHGjMD1ZSof7A0eoOEcd1KmvIwBqIHLuZ6YoGv0v3Cozs6VgaLK9FHoELQAAAMSNSYW5UpI/1l6KUBUVp9ZeBXL06OnbnKlJ3pmO25casp5qpcxyf2vZgqgkv0gKR2bbS6FH0AIAAEDcuGLp+fLcxdfZSxHqP/6j+9Y9kp8umz5Q2t9Jm+k5RxTU0QJ7Y47rHEFQ+22ZvlvGpz9tzwSg1+bS2rbvf98usGmzSA1Zuj5CPLfgerli8Rx7KfQIWgAAAIgbs4tHSkdurmwommGXRCAdKEObCTr7d+mk4coEGW2CqNfk0pEHzXodLbC3Plh6XHPRZLPPxRefHAxDj60DdZhjuoeFN/LyumvUzDF00v2cA1+E2Y6R46U8b5TMmzbGLgk9X5efPQ8AAADEvPWb98rDv35eVvzmO5LW1mKXIlZ0JCTIP37lx3Lr7cvk0nMn2aWhR40WAAAA4sr82cUyZ84U+d3iz9gliCX/uejTUnj29LCGLEXQAgAAQNz5p1svl/cvXCpPzb/WLkEs0Odz7YJr5I7PXW6XhA9BCwAAAHEnIy1FHvj2TfLC4pvkqfOutEsRzfR5fOKS5dbzmpU+xC4NH/poAQAAIG4drW+Sb/74TzJn41vy9Vcek5T2NnsNooX2yXrk8r+VtedfLj/65jIpGjHcXhNeBC0AAADEtaaWNvnp716W0g+3yA//8BPJb6ix1yDSVWZky/938x2SctZs+d4/XGPVVEYKghYAAADg99RrH8p/v/SB/N2bT8uyD1+TxM5Oew0i0V/OulR+e/nfyqeXniO3fOp8uzRyELQAAAAAW2lVnfx0xUvSWrJHvv7Cb2TqkX32GkSKkvyx8vC1t0vHxEnyv27/VMQ0FXQjaAEAAAAuL7+7Q3771DqZcWinfH7VEzKp8qC9BuGiAeu/ltwiW8dMkb+/fr5cfdE0SUyI3LH9CFoAAABAAK3tHfLCuq3yxIvvWYHr5rXPyOzSXfZahMqOkePl8cs+bQWsW66eJ9ctmCEpSYn22shF0AIAAAB6YQWut7fLs69+IGk11XLduhfkyq1vMUJhELUmJcsbk+fK04tuktrhuXLTFedFTcAyCFoAAABAH723/ZA89+oG2bzviFy6d5Ms+nCNzD2w1V6LwdpcOFnWzr5YVk27UKYW5cu1S+bK/JljI7qJYE8IWgAAAEA/lR9tkFUbSmTt+k+ktqZOFm5/TxZufktmlO1mtMJ+MuFq7bR5kpWVIQvnz5TFcydJYd4we4voRNACAAAABkFHKnzdH7reeW+bHDh2XOaV7ZLzPn5b5u3bIjmNtfZWMGrTMuS98bPkg7MXyHujJkvB8KFy8QUzYiJcORG0AAAAAI/UNjZbzQs/+HCXvLfzsOS0NsqkioMyZecmmXJkn3/+gKS1tdhbxz7ta7U3t1C2jZoguyfPlh0FxVKeki7zJhXIeXOnyrxpYyQnM83eOrYQtAAAAIAg2VtWIyWHq2XnnjLZtm2/lBxrlqK2Bpl6aJdM3LddppftkeLq0pgYWOOUUDV+muwonCSlQ4ZJUWaKTJ8yVqZMKpSpY/KkeFS2vUdsI2gBAAAAIdLR2WmFrx0Hq2T7zoOyY/dhOVDfKkUtdVJQXy15VeVSUFEqeQ01UlBX5Z+qI6r54dH0LCkfliuVGdlyZFieVOaPkiP5o6U8M1f2pmZJcWayTJ04WiZOGC3Tx42QSYU5UTmQhRcIWgAAAEAY6fDxJaXVUnmsUY4cbZDK6lo5crhSKmsapLyhVRo6RAo6myW/uV4KjlXKyIpD/qnU3lskrbVZspoa7CWRfH9IMwNypHS0nRLUNCi1JiZb8x3+AKSBydC+U00pQ+wlkSMjCv3TGKnMypXytCypTEiVtESfFGSkSH52howcnS/5uVkyMidD8oenS3FBtqSldh8bBC0AAAAgomkQKz9a7w9ix63bqtruQCatrdbU1NZh9Q2Ttu7mh5XH26Sjvd2ab/XnraPds5acJH/4siuYEpOSJH+oHYxSUiQjzT+l+DdITRVJTrYCVF5WuhTkZPqD1FDrNpquYxVuBC0AAAAA8Fh8NpgEAAAAgCAiaAEAAACAxwhaAAAAAOAxghYAAAAAeIygBQAAAAAeI2gBAAAAgMcIWgAAAADgMYIWAAAAAHiMoAUAAAAAnhL5fzsTF82u8heFAAAAAElFTkSuQmCC"
+    "final_model_workflow.png": {
+     "image/png": "iVBORw0KGgoAAAANSUhEUgAAA0sAAAGMCAYAAAALNjlTAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAhdEVYdENyZWF0aW9uIFRpbWUAMjAyMDoxMToxNCAwNzo1ODowMVIXxEsAAEgqSURBVHhe7d0JfFX1nf//z81KSELIBoFAILJviqIoiggqal1Bx7aO007tNp3ptLXa+bXjo79qO1P/7a9Ta7X//rpRnek42tZd6koREcVdEGQNOyEhCyEbIfvvfk6+XzhcTva75/X0cbz3fM9y7+Xee3Lf57scX6efAAAAAABOkWBuAQAAAAAuhCUAAAAA8EBYAgAAAAAPhCUAAAAA8EBYAgAAAAAPhCUAAAAA8EBYAgAAAAAPhCUAAAAA8EBYAgAAAAAPhCUAAAAA8EBYAgAAAAAPhCUAAAAA8EBYAgAAAAAPhCUAAAAA8EBYAgAAAAAPhCUAAAAA8EBYAgAAAAAPhCUAAAAA8EBYAgAAAAAPhCUAAAAA8EBYAgAAAAAPhCUAAAAA8EBYAgAAAAAPhCUAAAAA8EBYAgAAAAAPhCUAAAAA8EBYAgAAAAAPhCUAAAAA8EBYAgAAAAAPhCUAAAAA8EBYAgAAAAAPvk4/cz+mtHd0SPmRBimtqpPD/ts9hyuktqFJWtqOy5H6Funwv6qm5mapP9bmrF/f2C5t7SJJiSKZ6f7/+aWnJUr6sGGS4BPJyUyRlKRhkpWRJkX5eTI2b4QU5GRIof82MYFMCQAAAAw1UR+WWvwJZ8veCtm6r0L2V1XLgYojcrimUaqPtklGRrsMG9YoCSk1kpRSK4kpzc42ScnHJSGhXXz+KTnZlKX6y3zt/hCVKG3Nw5yy1tZU6exIlM7OBGltSXPK2ltSpa0lS6QtW44fS5e6hkTJHpEoY3IzZFxejkwYlSszJoySmRNH+cNVV+gCAAAAEH+iLiw1NbfKpj2HZcOug/JhyX7Zc6jBH4qOS/LwUkkeVivJqY2SktYgqcMaxOcL/VPv7PRJS3O6NDdlSOtxnbKkrWms1NYOk6LR6TJv2gSZN2W8zPQHqIy0FLMVAAAAgFgXFWFJm9KtfOtjeXvrHimrbpIRWfWSNPygpGVWSnpmtSQkdjWliyYd7UlyrCFbjtWNlvamQqmpGSGjslPlotlnyJXzZkjxmGyzJgAAAIBYFLGw1NDUIqs/3OUPSRul7Ei9jMgvkYzsA5KWXhOWGqNg0xqo441Z0nB0vDRUTZHszAy55vwzZem8yZKV3tXsDwAAAEDsCHtYWrdpnzz/zmbZWFIuI3PLJS1nh2SOPGyWxo/GujxpqJ4qtVWFMqs43x+c5sjCORMYLAIAAACIEWELSxqSfvv8m9LUViXD8zZJVs6hqGxeF2w6oERt1VhprJ4tCW058rXli5zQBAAAACC6hTwsbSgpc0LSoZoKySl8R0bklJklQ09Dbb5U718gmcOy5Zs3LZa5k8eYJQAAAACiTcjCkg7acP/jr8nWg2WSO+4Dyc7fF5N9kUKhpnK81JSeK+Py8pzQNLkw1ywBAAAAEC1CEpbe2XZQ7n74Jckr3CQ5Y3c61zfCqXRAiKrSqXK0/Cz5zi2X0TQPAAAAiDJBD0t/fHWD/OGVd2XMlLWSkVVpStGdxvocObhtsXxq8Tny91eea0oBAAAARFrQwlJ7R4f8n8dWy1s7tkvh1Fedi8aib1pbh/kD0xKZO3Ga3HXrUklJSjRLAAAAAERK0MLSv65YKTsPfyyFU14fEqPcBZte5PZQyQIpyJgu9391OUOMAwAAABEWlF/kv1r5pmwv3SHjpq0hKA2Q/rsVTl0nZXW75P4n1ppSAAAAAJEy6Jql7Qeq5M5fPynFc1ZKUnKLKQ2dn934orl3qm8+eZW5F9u0hmnvpmvle393vcybOtaUAgAAAAi3Qdcs/Z8/viJ5498LS1CyNpe95YQjO+07ss0JUTee9U9mjb7592v/JLcvvt/MRQetYcqb8Jbc9/hfnX5gAAAAACJjUGFp057DUt1wRLLz95uSyLh/ze1OYLp40vVyRt5sUxq7RmSXy/H2I/L+jkOmBAAAAEC4DaoZ3o//+Ff5qHyljBq/1ZSEntYgac3SivX3mJIuGpK+tug/Tln2hQX3yOwxFzj3lQYqDVaLJt0gy8/6R1N6km3Kp7VNE3KmO/eV1+OFWnV5sZyRfoPc8/fx0bwQAAAAiDWDqln6eE+5ZGQfNnORtbtqszS21MnozPHOvAalzNSRJ5rqPbj2W04A0qZ6a3c945Tp+hqg7DpKg1J989ETZU9t/L9O4NKAFU4ZIytlk//fFwAAAEBkDCosVdU2S0pqdF5PSWuCtBbJsmEqe/goU+JNt3HXImmwUnkZhc5tuKSkNkpNXbuZAwAAABBugx7gweczd6LEsZZ6c6+rlkib7dkpPWWEU9vUm7uuWHHKdqq3kBVsPl9QLn8FAAAAYIAGFZayM1Ok5fhwMxdZ2mdJw5A2oVMaeLTZnW1Op5PWLPVGR8gbnpJ5ynaR0Hw8Q7JHJJo5AAAAAOE2qLA0e2KBNNaFt8alO0um/I1z++rOx51bDTw6MENP3LVQlgauDw6sMXOR03A0X6aNzzdzAAAAAMJtUGHpE/NnSVPNVDMXOdrcTgdheH3Xs07fJKVBqDh3pnNf6ToahALlZZx64VetfZo+ep6Z66qhioTjR6fK1fNjfxh0AAAAIFYNauhw9dkf/Y8k5f5VsnJLTUlo2T5Ebhpwvrvyk2buJPe6Ouqd1jZpiLIDP9jhxpXdh7tMae2Uhq491VvCNnx4Q22+1B24Qv7nu7dKYsKgu5UBAAAAGIBBhyW9MO13H3paJs55ThIS20wpBqqjPUn2b7lG/tfN18iCmUWmFAAAAEC4DbraYk7xaFly1gw5tHOxdHZG2dB4Mahs90Uy74xJBCUAAAAgwoLSxutryxdKYdYkKd2xUDo6GcFtIDRolu2+QLJTJsm/3nq5KQUAAAAQKYNuhmc1NbfKDx95WTYfKJFx01+V5OTjZgl609aa4tTMFedNln+77ROSlppslgAAAACIlKCFJWvFC2/LE2s3yvgZa2R4xhFTiu4cb8yS0h2L5ar5Z8k/XHMBAzoAAAAAUSLoYUmt+qBEfv7Ea5I99gPJKdgtPl/QHyIuHKmYKBV7z5Ov33SxfOK8yA/BDgAAAOCkkIQltf1AlTzw1GtyoLJC8oreC9vQ4rGgrqZAag7Ol8xh2fLtT18mMydEx4V9AQAAAJwUsrBkrdu0T377/JvS2FIh2ePek4ysSrNk6GlqGCnVBxZIQnuO/NMNC+WSs4rNEgAAAADRJuRhyXrx3Z3y0ItvSUJqhQzP2SyZ2eVDonmejnJXf3S0NFbPlqa6XPlHf0haOm8SfZMAAACAKBe2sKTaOzrktY175al1H8iuQ0dlZP5eGZFXImkZR80a8UMHbqitmiT1R86Q8XlZcs35Z8rScydLShJDqwMAAACxIKxhya3yaKO8/N52eW79x9Lc3iAZudslI6dUhqXVmzViT8vxdKk7UiiNR2ZIkqTLtRfMkivOnSYFORlmDQAA4lNt43H585pNsmnXIdl56Kgcb2kzS+LXsJQkOaMgS2afMUZuWjRb8kemmyUA4kXEwpKbDgbx7PqP5P3tB6WhqVkyRtZK8vD9MnxElaSl10Rtcz3tg9RYN0rajo2V+qO5kpqSLPNnjJer58+WOcWjzVoAAMS3NRt2y/1/XifF2T4Zk+GTgowESU70maXxq7W9UyobO6S0vlN213TKV5YtkKvOm2KWAogHURGW3I7UN8mGkjL5sGS/bNxVKodrjsvIkfWSMKxMUofXSMqwBkn1T0nJLWaL0NOLxjYfz3BqjlqPZ0l70zipqcmUnMxUmTtlrJw3daITjjijBAAYajQo/d+n1snFRYmSO3zo9sc9erxD1u7rkE9dPk+WLZxpSgHEuqgLS4Eamlqc8PTx3nI5UFkpB6tqpaKmWdo7OiU9vUWSU2tFko9Iamqj+BLbJcV/qxITWyUxqdW5nzKsq8xNg4/qaE+StrYU535rS5p/PtG/LEM6W3OltTlLmo6liM/nk7ysVCnMz5KJo/Jl1sQCmTt5jGSkdW0HAMBQpE3v/v7eP8nlZwztoGTVN3fK8zvb5Fd33kgTfCBORH1Y6o6GqNKqOik/Ui8HK2tk9+EKaWo+LjX1rdLR2S51jS3S0tohnf7/jtZ1ONvsWf+sFC+43rk/ckSC+Pz/pSQnyIj0FEnwJUp2ZrKkpQ6TCfn5Mi4/WwrzRjgHu6z0Yc42AADgpN/95V35eOs2mV+YZEqwsbxdxk2cJP+8fIEpARDLYjYsDYTWEA2hlwsAQEh944FnpDClXsZnMdKrVd7QITvrh8sv71huSgDEMurMAQDAgOiodzqYA07KTfPJ3oo6Mwcg1nGEAwAAA6LDgw+FUe/6Q/89hsKw6cBQQVgCAAAAAA+EJQAAAADwQFgCAAAAAA+EJQAAAADwQFgCAAAxb9GiRXLLLbdIfn6+KQGAwSMsAQCAsLv22mudycvSpUvlxhtvNHMAEDmEJQAAEPPWrl0rjz76qFRWVpoSABg8whIAAAAAePB1+pn7cc/n88kQerkAAITUpXeskC+dN9zM9Y9tgrdy5Urn1k2b4WVmZsqTTz55Yj41NVXKyspk6tSpTplatWrViZqkefPmOcvcZdp/6fLLL3fuW++//77s2LHDuW+Xa9ns2bOdx1BVVVXyyiuvOPcH4rfvHpPV933BzAGIZdQsAQCAqKfhacyYMU5TO53q6+vl4osvNktPp8FJg1BpaemJbTQkaajSyU3nN2/e7KyjwSkvL++0dQAMTYQlAAAQ9Zqbm0+phdJaJq0J6m70Ow1LGqi0L5OlQUjLNHS5aYiytU16q4+Vk5PjzAMY2miGB4TQ6g93y4adpbJl72HZe7hOOvj8RbUE/zFifH6mTC/Kl7OmFMrSeZMkMYFzSkB3wtkMzz2vNAxp7Y9tVqf33c3wdDQ9DUaBzenc+7LN8HR73Y/V03PrC5rhAfGDsASEwP6Ko/Kj/35Vjh9rkAkjfZKb5pNs/6Q/xhG9NMzWNHXKkaYOKW1IEF/ycPnWpxfJ5MJcswYAt1CFpcBlhCUAkcIpUyDINCjd/uBzMjqlUZZOSpKpuYmSOzyBoBQD9D3S92pKbpIsnpAgRWmN8q1f/kVKSqvNGgCCpa6uzgktXlJSUpzlg9HS0nJiwAY3LdNlANAXhCUgyLRG6azRPickIbYVZyfKgvEJcq//PW3v6DClAILB9iWytTiWzmugcfc1Ggjt06RhzD1Qw6JFi5wyrUkCgL4gLAFBpH2UtOldrAQl/RFxyy23nDZpMxV0KcpKlDRpluff4scVEGw6+pzWIrmPP7Z8sLRZnU7aNM/uu7Cw0GmmR1gC0Ff0WQKC6N//c5V01Jc5zbhiQWAbf2sgP1gC+w/Ek7017XIsdZT82xeuMCUA1GD6LMUz+iwB8YOaJSCItu6vktEZsd/8zoakwOYxQ5X2Y9p5sMrMAQCAoYKwBARRWU2jjEiNj4Ec9EKO2rbffQ0THV3KNmfRSWuTlDbbs/0CbNM+d1M+9zY6dXddlGiV6X9PK2qbzBwAABgqCEsAPJWXlzu3RUVFzq0GJXuFe500TNmApEPz2mF39VaX2+F6NRxpMz+7XVVVVY9X3QcAAIgWhCUAfaLXJHH3RbJhqrdaIg1I7v5QR44c8RzOFwAAINoQlgD0SC/qaLmb0tlapezsbOe2Oxqm3NvZpnux1hQPAAAMPYQlAJ4KCgqc25qamhOBR5vQ2eZ0ttldTzQY6dXxtcme3Y4hewEAQKwgLAHwlJeX59QqaRM6W3u0YcMG59aLhqpA9ur8g724JIDoNCwlSVrbuSSHm/57JCXEx0A/AAhLADxoLZL2K1q5cqUzb4PQjBkznFtlm+EFsjVSyjbhs+tqDZVthgcg9p1RkCWVjR1mDqq6qVOKRo0wcwBiHWEJgNNUzt2vyDabs7R2SZvP6dXv7TqBzel0Hd3OrrNo0SJnHS3TgKRl+jg0wwPix8ziAimtp2bJ7XB9u8zy/7sAiA++Tj9zP+75fD4ZQi8XEcDV7OMXV+QHTld5tFG+9JMn5MrJiTJyGOdfG1s6ZeWONnngG9dL0aiRphRALOPIBgAABiR/ZLp8ZdkCWbuvQ+qbh/bJSA1Kr+/vkL+9/GyCEhBHCEsAAGDArjpvinzq8nny/M422VjeLuUNHUNm0Ad9nfp6N5a1OjVK1yw8Sz65ZI5ZCiAe0AwPCCKa4cUvmuEBPSs/0iCPrd4oH+0qk/0VddIxBP7e6qh3OpiD9lG66ZLZ1CgBcYiwBAQRYSl+EZYAABh6aIYHAAAAAB4ISwAAAADggbAEAEAs8/mYmE6fAAQFYQkAgFin/XGZmOwEIGgISwBiRn5+vtxyyy2yaNEiUwIAABA6hCUgQvQHv/7wd0833nijWQoAAIBIIywBEfboo4+emJSGJnirrKx0/p3Wrl1rSgAAAEKHsAREkc2bNzu38+bNc24BAAAQOVyUFgii/lyUVpvhFRYWnqhRUton5/LLL5fS0lKn9mTp0qWSmpoqdXV1zrrKrm+3t6qqquSVV14xc101VO+//75MmDBB8vLynLLm5mZ58sknnfvq2muvdcqUruNerssyMzOd+ypw/0qfn9230sfbsWOHmTu9lmzVqlVO7ZDlXm5fs5o6deopgdG9X93Gva42XdTnpv9O3b1O5VVj57Ved7goLaKWjnzG3za48ZkAgoaaJSCKZGdnO7eNjY3OrdLAMmLEiFOa6tmQYst00nktd9PAoYHAva2GIDcbMHS5DQ4aQFJSUk5sp5Ou59428DloEJo9e7azzA7EoAHHLteAo0FQlykbcuxyfY26TCd93u5t7X67o6HR/To1OLn/LQIfq76+3pn6GpQAAMDQRFgCoogNN1qT4rZy5UpzryuIaEixTfYsDSM2+FjuGhi1b98+J3zZwKL08dw1RvocNGy8/vrrpqSLhhe7rX0O7lokrTGy4WPu3LlOGHG/Dvs8ZsyY4dwG0tfornVy6y3UaBByv06dt7Vi+lz19ehrt8rKyk6pNQMAAPBCWAIiTGtg7KQ/8gODgYYZN1v7pKHGva27SV53NMAouw/V0tJi7nVJT093bgODi3tbu70tC6ThRMOI+/np5KbhRQOXlutrsfRx9d9Bm+LpMnew6yv9N9PnoHR/Oq/NEa0xY8Z0+9wBAAAs+iwBQTTYPkuBtCmZhg53gLL9eQL7BwXSoBFYsxS4rW1W56656u55ubdVPT0Hr/12xz6eCuzTZPtNadix/waBr0ub2GnwcdeOBb4GXceGJ+XeX1/RZwlRi/4pCMRnImT2VxyVleu3yaaSQ7Kr7Ki0dfDvHCgpwScTR2fJ7DMKZNnFs6Ro1EizJDYRloAgCkdY0poW7fujIcXdzC2QV1jSgKOhx4YSr1ATuI7lLlc9PQev590br+erAgNef8OS3b6nf+e+ICwhavHDGIH4TARde0eH/Gn1R/LY6o0yKz9BCjITJGd4giT6/6lxqnb/R+/IsQ453NAhW6o65eZL5sinLjtLEhNis0EbzfCAIBqVlSZ1zaH9A6UBRsOBhgB3EzUNBO5BDZQGBg0Olm6j27pDUCAbfs4//3znVunj6LbaPE63dT8HS9fR4KK0iZ3W5AQ+H12u67nXVXY/OrBF4OsoKChwbmtqapzb/rLbachyT+7BKnrT2NLpvLcAgKFJg9Lzb3wk101LljkFSZKfTlDqjv676L/P7NFJcv20JFn19mb5zxe7P7kb7ahZAoLo3/9zlfgayuSMnCRT0j137Ud3eqqh0WXuAR00vLhriGwNjI4yp/tQgev01FwusOmaV62PbSZnuZvlaSDS2ic393L7+i33/nvar31dfa1ZUrqNex/Ka7vu7K9tl7rEPPnhl64yJUAUoRYBgfhMBJU2vfva/c84QSk9hYTUXy3tIs9ub5Uff+UamVyYa0pjB2EJCKIX390pT7zyllxa3HtYCrXAUDFUdRc4tVzDYF/6Va0/2C6XnH+23LRolikBogg/jBGIz0RQ/fKZt+Tg7p1OjRIGZltlm6TljpPv3LrElMQOmuEBQbR03iTxJQ+X3UfaTAkizY6MpzVdlt7XWjm92G9vDtW1y5HmZLnuwummBAAwlOhgDtpHCQM3Kj1BtuyrMHOxhZolIMhKSqvlzv9/pVxYlChFWYmmNPyoWTopsMmi0iZ5tn9WdzQovXGwU/79i1fKzAmjTCkQZSJYi6CD2sBbRAeEoWYpqK741u/ls+ek0UdpkGJ1oCTCEhACGph++IfVkpHQImMzOiV3eIJkpnKUjQU6mEN1U4eU1otTo3TXZ5YQlBDdIhyWxs5cYOZgHdqynrAUR/oz0i26R1iKAYQlhJMOM/rcm9vk3a37ZdehI1JR22SWIJrpqHeTxubIOdPGO03vUpIiVzsI9AlhKeoQluILYSk4CEsxgLAEAIg7hKWoQ1iKL4Sl4IjVsERvNQAAAADwQFiKBD3jw8TExMQU/AkAgCAiLEWKVo8zMTExMQVvAoAYpBditxeJD7V58+Y5o+W6L6eBnhGWAAAAgCDTQKLBJHBatGiRWQOxgLAEAAAAhIhe1+/RRx91Jr1fWFjo1PAgNhCWAAAAgDDQi6E3NzdLTk6OKUG0IywBAAAAUUSb6rmb7i1dutQs6aJlWjulfZ3sOl79ntzLb7zxRlN6qqlTp55Yx2s93Yc+vk497SdeEZYAAACAMNCAk5qaKvv27TMlp9NQkpeXd6Lpnk46HxiYNOSUlZU5y1etWiWZmZmn9IfS9bXM7kMfU7dx0+ejk25v12tpaTktEOnjK13+5JNPOveHCsISAAAAECLumhu9X19f7/Rd8qKDQmgw2bx5synpUlpaeiKwWFqmzfpUZWWls98RI0Y480rX13UsXTfwcSdMmOCso9tbuo4GOnew0qaDr7zyipkbWghLAAAAQIi4B3jQKSUlxQlOXrKzs51bre2xAUsnHRSiNxpodN/KBp3y8nLntjsainTf7sfSxw6ktU1DFWEJAAAACBNba+QVSiytBXIHLDuFgtYseT1Wd7VfQw1hCQAAAIgCNTU1zq32NRqM7vaTnp5u7nXR2iitXUL3CEsAAABAmMyePdu5tf2N3GzfI21Gp/2XLK2FChzgoSfu/Vi6j8DmfFVVVU7fJnctlz7uUBvxrieEJQAAACBENLC4+wQpbebWnZUrVzoh5vLLLz+xzZgxY/o9wILuR2uO3PsIDGhr1651mtu5n6M+7lAb8a4nvk4/cz/u+Xw+iYqX638e/idiZgAAQTFUj60RfN2X3rFCxs5cYOZgHdqyXlbf9wUzFwH8zggq/Zx/6bzhZg4D9dt3j0X2ezFA1CwBAAAAgAfCEgAAAAB4ICwBAAAAgAfCEgAAAAB4ICwBAAAAgAfCEgAAANCNpASfdDC64JBFWAIAAAC6MXF0ltQ0EZYGo665U8Zkp5u52EJYAgAAALox+4wCqWjoMHMYiMMN7TJzQr6Ziy2EJQAAAKAbV18wXTYe7pDjbdQuDURre6dsrvTJ8kvmmJLYQlgCAAAAujG5MFeWXTxL1u3vkJZ2U4g+0aD05sFOWXzOZJk5YZQpjS2EJQAAAKAHn73yHFl4znR5bkebbKtsk+pjHeLPAfCgg2Ec8f/77Kxuk5U7O+TMGZPkH66bb5bGHl+nn7kf93w+n0TFy/U/D/8TMTMAgKAYqsfWCL7uS+9YIWNnLjBzwdNQeVCeuetKM9dl4Zd/IhPOu9q5/8xdV/nXOSBTFn9a5t/6v50ya/X9X3ZuL739N87tO4/8m+xc85hk5I+XG+590Smztry4Qj584j659bcfm5LgOLRlvay+7wtmLgL4nREyJaXV8viaj2TLvgo5WNVgSuGW4P/8jc/PlGnj8+T6hbNitkbJIixFAgcxAAi+oXpsjeDrDkVYsgHGHY6UBqS5y7/ulNmwpG649yV/EBrn3FfdhSUVuE/CEoDe0AwPAAD0avPmzdLW1mbmQkNrlDS8nH3THaeEGqW1Qu4yrVXS2qJ3HvmBKemerqfrr/vNv5gSAOgbwhIAAOjVT3/6U5kxY4Y8/PDDIQtNW15+yLmdeVXfamW0pqns4zeksuQDU9K9mVfc5txqbRIA9BVhCQAA9ElJSYncdtttJ0JTZ0dwrz2jTeu0FqivtKZJ13/z93eZku5pUz2tXdKaK63BAoC+ICwBABBGe/fuFe1DG7TJv0/P8iBPGo4sG5o+euYBaW9tNqWDV1+xXzJHFZm5vrnw8/c6IWvfu8+bku7ZwSBsDVao7Fn/rOe/Ydgm/3PwLA/BdM8993S9aCBOEZYAAAiziRMnOgMOBWXy78+zPMjT5z73ua4n7zd58mR56KGH5Mwbvi6JyammNDLyJ58jY2Zd1Of+SNofSgd86EvTvYEqXnC9579h2Cb/c/AsD/J09913d71gII4RlgAAQJ/YkLR161YnPPkSgvszQkOP9kHqr/m3fs+57Ut/JO0PpU33Nq38lSkBgO4RlgAAQK/uvPPOEyEpKSnJlAbX6KnznNu+NKlzc/dH6gs7MET5trdNCQB4IywBAIBezZ49O2QhydIBG+wQ34GBSa+f1FOIsv2R+lIzpY8z0FosnJSRkSGlpaVmDohPhCUAABA1NPToxWM1MD3ypVknpkkXLTvt2kuBdLu+sk33MHB5eXkhv/YWEGm+Tu2hN0ToqC1R8XL9z8P/RMwMACAoYuTYqqPhLVmyRPbs2WNKBimCr/vSO1bI2JkLzBysQ1vWy+r7+natqJAI02dCR0h87bXXnH5s8UY/24iMiH53PBCWIoGwBADBR1gKO8KSN8JS7OOzHRkR/+54oBkeAAAAAHggLAEAAACAB8ISAAAAAHigz1Ik9KMtMR0Mo0Mo2s/y3kZGsN9L3sfgGtT7Q5+lsKNfhzf6LMU+PtuREY19lghLkdDPsMSXNbJC9cXlvQ2/ULyXvI/BM+j3h7AUdnz+vQ2VsPT444/LihUr5IUXXjAl8YPPdmREY1iiGR4AAAD6Ta+zdPz4cTMHxCfCEgAAAAB4ICwBAAAAgAfCEgAAAAB4ICwBAAAAgAfCEgAAAAB4ICwBAAAAgAfCEgAAAPpt2LBhUlVVZeaA+ERYAgAAQL8VFBRIQ0ODmQPiE2EJAAAAADwQlgAAAADAA2EJAAAAGCK2vLhCHvnSLDPXvdX3f1meuesqMzd0EZYAAACAKGHDjE4NlQdN6ek0zOg6BJrQIiwBAAAAUSYjf7xsefkhM3cqDVFlH7/hrDNYlSUfOKFLb90uvf03csO9L5q5oYuwBAAAAESZKYtulp1rHjNzp9IQpUFpzKyLTAlChbAEAACAftPrLB09etTMIdiK5l3p3GqzvEAaouYu/7qZO0mb5L3zyL+ZuS499VHSdV/+8Wec+3qr69nt9ZYmfoQlAAAADIBeZ4mwFDoZ+eNkyuJPy861fzYlXWx4mnDe1c7tYMy/9X/LFd/+g3Nfb2/97cdOGU4iLAFxZt+7zztnhnqaeuowCgAAokPx+df4/2YfOKU/kYans2+6w8wh1AhLQJzRM016ZshO2qZZz0ydWjbOrD0wXtX8XjSYeTUfAAAAvcuffI7zd3zTyl858xqaNDzZJnoIPcISAAAAEKV0oAcd+U5bhWho0kEdBnvSE31HWAKGKK0dcjfNs1X8tiOou8rflu1790XnVs9qaedSu20g2xRQffjEfc59dydRr6aCAADgdDOv+oJzqyPgaWiac+1XnHkvmaOKnL/R/ZGWNcrcgxfCEjAEaTjRM1W2Wd7CL//EGQVHA5IelPWs1Zu/v8tZV89kaeDRdSacd5Vpxndq075Atimg0nbVet9eq0GD17rf/MuJjqQ66b70OdGXCgCA0zkDPax5zPn7q03zulMw/fwTtVBK/+bq3/C+qCz50NyDG2EJGGL0wKkHW3umSmm40bI9b//FmZ9/6/ecM1O67juP/MAJT8EYdUfpQVsDlPtgb0fe2f/+S84tgNhxaMt6poAJCDYd6EHpic6e2BOez9x1pXMSsnzb287Jzp5okz79u2xbgujffpzk6/Qz9+Oez+eTqHi5/ufhfyJmpmeX3rFCxs5cYOYQCfqHb/V9J4NFsITrvdXmb3rgtIFEB2bo7iJ3eubKruc+GxVYexS4z+7oQVcPwDaY6ZkuPYB31VKdGr76us/BCMV7yXc0eAb9/vTj2BpJe/fulSVLlsiePXtMySDFyOtGGIXxM5GcnCz19fXONZfiCcf2yAjVb67BoGYJGIK0Fsk2gXNP7qDSUH3I3OsafQcAgEDjxo2T8vJyMwfEH8ISMMRk5I51mtj1RMOR1j5pvyKt7bH9lyztQNoXGsrc7Og9jdVlzq2bPid9bgAAANGCsISI0OZY2kRLR0VDeNlrM6y+/8vOraXztgZJw5E2ydN+Re7+S27agbQvtL20m+5Xm/e5B3Owz8XdjwoDY0ca7GmwjMDvn92GGkQAAE5FWIpj+sNHfwAFTj39iOoL/dHstV/3hOiltTva5E7Djvs9m3TRMiccaZ8mDUe2SZ6746f9MW0DlG7nHhI80IWfv/fE49hApPvV/dnOpzrVV+x3ntNQov/O9vXbKTDAAgCAyGKAh0gIwwAP+qNLf6RqMyr3qGP6Y1eHiO7PD9PeOt7rjzx3J/6+0MDWXUf/aBPrAzzgpGga4EHDkn5H7ZDqSr9L2nTRXdZfWkukQ7PfcO9LJ5o9BorW7x8DPAwQAzwgUBg/E8XFxfLqq6/KxIkTTUl84G90ZDDAA8JCa366foS9dNpY/Do/1M7gA7FCw4vW2NEcDgCA6EBYihIrV66U+++/X44fP25KBk6bS2m/kO7OKgcKbFanZ7yVbcanP960s79d3ld2fTv11j9Ja7Dc++/ueVl2n1qLZtcJbMYU2BQxEj9CS0pKzD3EulC/l8OzC5zbYzVdI0sFfn69mjy6P//dNYkM/C411VaYJV3s49jvh523fZvspPtxC3x+dgr8rsa6gwcPBuXYDACIPYSlKFFVVSXf/OY3nerswYQm+2Nn9NR5zm1v9EfNzrV/dmqb7KTBSMttLZQ2C9LwZZf3xv7Acm+jzQG1aVDgjy1Lf+RpKLP77+l5uek+ta+NLteaNK1Rs4+hz0ObHOrZeruPwFHdwuGHP/yhnH322fL000+bEsSqUL+XNiRpaNLvsn5e7WdXJ+X+Duh9/czb5XOXf935TrjpCQU9gaLfQV1Hvyf6vegLbaqn6+t2+j1y91vz+n4pbZIbymtlRcKqVasGfWwG4lVSUpK0tbWZOSD+DLk+S3fffbeZi6Dvf1/8T8TMdNm4ceMpP8AKCgrk29/+tjy9e5iMO3ORKe2d/pDRHzDuvkoaHvRHjmX7RNh+C4H9muz69sdPf/ss2R9wgf0u3OX2sfWH1q43nnY6+Nv1+/q8Ah9X2ZqlS2//zSmPMZh+GYNtP3vbbbfJww8/7NyfO3eu8xlctmwZ7aEjIBTv5QNrq4PSZ8l+XvW7pp9fL7qNnlSwy72+A4F9ltzfCSvwuxF43PA6jij349nHsd9HFfj8+ita+yzpe67vvbLH5q985Svy1ltvyZo1a5zy/qitrXWO9/RZQsiE8TOh/e/0WLh48WJTEh/4Gx0Z9FmKsKgISn109OhR2bdvn7Q1HzMl/WPPUCv9YWPP/OoPHf0xo2xTHP1RpD+C7OQOVgOh+/e6Do/X9X30x1ZgsBrM89IgqMGr6/44p3ZLH0O31x+IA7Fn/bP+vzu+AU/2x7XasGGDLF++XD7xiU9IR1urKUW4hOK93PjU/dLe2mxK+0e/D/bzreFFv5/uoKGBxC7XSWtX7efb1vDkTz7bue2Ofr8Kpp9v5gZHv1/2YsW5E890bvU5Wvr8BvNYg31//D8PvcsHOdmgpPTim9oKYMaMGfKLX/xCvv/97/d70hqquro6s0cg9v385z/nwrRBoCeF9ViP6DKkapaihv+Pb+AZH3vmctiwYc4ZSz1zqWcwB3JmQ79oGhK8aoLctTPdnT0O1N+aJa8z2cr92O4z2xpm3COA9fV5BT6u6q5WS5+Tlrsfp6+CWRvhPit99V2PcNYqzELxXva39tfq7rNq2e+L+3vg3qa770lgzZLX92SgNUvuY4Hdh1t3x52+ioWapcBj9EAwGh5CLoyfCf0saw2rnpC+5557TGnsi0TNUmALmqGImiV0KyMjQ26//Xbnj+fPfvazAf8RVvqDRc/w9laTkpY1yrl110J58aol6om7dsdNz0jrskD6o07PsOsPQdXX59UfGtz0h58+jv4QDDd9P/V91fdX32f9wYXYFPheJiQlmyXBpd8XDSbdnTDo7nvSWF1m7nVx1wZZgQM8DMT+919ynp+ttdZpMEEp2ul3NljHaCBebN68Wd577z3n/q9//Wv69CEuEZaixN/8zd8E7Q+w/mDRH0h61jcwGLh/NOlZZ/2xo2eh3cFKz0zb4GLp2ey+Kj7/GieU6BkSS/epAU47oAfS56FnuHW5btOf59WTwPUrSz50bu2PzHD56le/SkiKE+F8L7XZqn7v7HfAfocs9/fE0nUCm6tOWXSzs509Fuj+tNZosNJzxzjPT2uu3JP7ex8vFi5cSEgCAujAVNoUuaGhwZnXZniPPXbyGBUrYmnEWj3Gu4+3tiWPHte9jr963Ndye/y383YKHEFV96e/m3TyWj5UEZbilDbT0QCiP4rcXwz90eSu3tUaF62J0mBl19EBF9xniOff+j0n/Oiyvnxx9Ey41hbpjza7T/1BpzU73Q20oOXaVEi30S9zX55Xb3Sf7j4htkmT/sgMp3PPPZeQFCfC+V5qszkNQ/Y7sOGpB5zviJt+T/TEiPs7op9xN92PfpfssUD3F4wmHnaYc3fNkv3e6x/0eDJ58mRCEhBAg1HgKHjadynWLF261Al92g81mulxVY/x7mOunrByn2TWUYTd9rz9F+dvhP4u0+3174Aep+322nIo8HedPSmny/vbbSFe0WcpEvrRlpjRWCIvVO1nB/Le6tkj/bFr6UGQg1nfheK9HKrfUXf/JTct19osdx+pvorWPkvBRp8lhFwYPxN6HbJ169bJa6+95owQqTWwsTQynl4WQL+TSkeq1b5XOtppLPRZ0pog/R2gx2ENQ/bEtG2+rSfIbJ9Vr2Oznpx290/V/blHJ46EaOyzRFiKBMJSTImWsGSDkruzvh4cD+94v181bkMZYSl4vP6oev2x7g/C0gBF8HXr5x/eIvqDLwKfCa1l0toZ7YM9ffp0Z7AHHf0xFmlgWls3PurCkl3upiet7IBaGo7sQDs2CLkH++mOOywpu79IICyhC2EppkRLWLI/RO2BD/1HWAouPVOpTV3dBvP5JCwNUITDEn+jThfxH3xh+EzoJU50FLy3337bqVHSSQPTgQMHYqrZqrtmKdLXQuwpLGk/Im0i5z7GBoYbu45ur/f1+OwOUoEjowYiLHmjzxIQY6r3fmTuebMdM+2kB1832xHUvVy3sQdJu1zDmZsut+tYuq17X7ofN7sf3c6uE7gPFficbWdUy71MJ32OiDytVdI/yu6JIA8MDY8//rjT1+dHP/qRE5p0JLxPf/rTMdm/T0PSU089JR9++KETlKKRBh+tNerpGDvziq5LHOjfXQ1Nky46+Vq0uV7gyKjoG8ISECN0wAo92GntUmCHTEuDiB5Q7Q9XPQOlZ6ncgUmb8ukB165Tvu3tEx06+0MDjnYmtfvRSfcTGJj0+eoBW5fr87EdUi1nP+ZMmF3nzd/f5SyzwU0HK7HL9cyYvgYCEwBEzhe/+EXnmmNu3/jGN8y92PGHP/whqkOSpX//3X+r9e9o4EjFGqTco6S6B9WyI6O6T4Tq39Hufk/gJMISEEP0TL6GBTvKn/sgp7UxeuDU0QstPXBqMLIj5NiDpD37pLS6XQ+u/aEHWD3oXvj5e01JF31u7oO50jJ7wLYHcg1oyu5Hw5Cl69h+MFtefshZ333At00I9Do/AIDIefDBB53+SUqH2NcRQ2ONPu9o425JoZP+7dZ+SBqYbJn+HdW/74FsbVLgMv3bqX9rNUjZfeiJx0gO5hArCEtAjNEDntaw6EFPQ5MNTPbipHrwswdCndzhRQeD0INtT9X4fWEvaho4NH1gx1Mv+vj2osV2P3YY6kD6+ryu5QMAiLykpCSn2Z3e3nnnnaYUA2X/vgdO9oShu+mznujUABXYv8j+PdVrXgbS/bj3q5Ob7iuS/ZWiFWEJiFF60LOByd3HR5uxBR4MQ3XmSEfQCXwsnYJJa5a8HqOnTqoAgPD585//LNdee62ZQyRtWvkr56TkQEYkhTfCEhAH0rJGnTibZGtrvGTkjnXCVSBb06NsrVNjdZlz60UfT9narIHqbT/uWigAQHTSARK0dgmRpU3btTWG9k9C8BCWgBihgze4B0ZQ2vZYa1404OhZJA0X2jTOTbex2xXN67qgrXsQBjsohJvu030lcF3H3ZHU9j3Sx3cPtKDtqgMHeOiJez+Wu8OpNiPQ5xa4T13uflwAQGToEOKIDvo3lZYXwUdYAmKEtiPWAOPuu6MdON3ti7W5nYYP9zo6VKg9cOqBVJvOaT8mu1w7g+o2brpPDSl2nYLp55/WWVTX0TJ3H6ldbzzd7wvk6n7cz1n3ZweO0ACozQrdz1cnXa6vBQAQWYQlxDsuShsJXJQ2pkTLRWlDyV77yB284hEXpY1uXJR2gLgobdQZCheltfSirq+++qpMnDjRlMQHPtuRwUVpAQAAEFeGDRtm7gHxh7AEAACAAdPhw4F4RVgC4DS/i/cmeACA4KuqqjL3gPhEWAIAAMCANDQ0mHtAfCIsAQAAAP2kl7Fwj9SqU+AlPhD7CEsAAADAAOglNPTaRjrppTk+fOK+fl1vMJL0eoUa8PQaiegeYQkAAAADMm4c17yz9NqAGp702oCIH4QlAAAA9JsO7pCUlGTmoDJyxzq3WmtjBTbVcy/TZnvanE9rdwKXaw2Ve7vKkg+ccmVrhdyTm26rk27jXsfuo+txr3Tur/vNvzjL7DUXdTu9r+vY7Sx3mU763N3s6+nucWMRYQkAAAD9xuAOp2uoPuTcZuSPOxFoFn75Jyea6p190x1OSHEHpobKA7LhqQdOrKPbamDRGipbdsO9L8mbv7/LWV+Dh+5Dm/3Z5VqjpY/lptvrNnYdfeyXf/wZ57FnXvUFZ5/KPj/3qLhlH78h5dvePrGt0uekzQx1O1ueOarotMfV1+N+XH1u+rixirAEAAAADJLWDmlA0VCitrz8kIyZdZFMOO9qZ15pSFH73+8KKtZl3/yduddVa6T70RBjaYC64d4XnfubVv7KCSDa7M+aecVtzq27/1FG/vgT26juHrs77vDkfk76XKz5t37PuQ3s9+R+3OLzr3FuY7V2ibAEAAAADIAGCNvUTJuzaW2PDSVaw6I1NHa5nby4A0hTbYVzOzzb+2K/9RX7T3lcnWyTut5ogLK1Xz3R9dy6e072eTdWlzm3XtKyRjm3x2rKndtYQ1gCAADAgIwcOdLcG5rco+Hp5K7tUVqz5F5uJxuoBirwce3krsVCcBCWAAAA0G/l5eVDPiz1RGtntBaov3qridF+QlprNRC6nR2Ewl2b1ZvunpPte5WeO8a5jUeEJQAAAPTb8ePHzT140b46Gk50YAQ3HS3OPcBDIA0xWiOlzfosXd+OPDfpomVO8z4dec4tsImfPrZ7tDr7PIrmndpk7/CO98297nk9J/XXn33RCYXxXKNFWAIAAACCTJvk6chxgf2LLvz8vb3W6ujgChpO7DbaJ0m3UxpM7AVw3fu1o9tZGmLmLv/6ieX6PHQd92PrgA32+QWGukD6nOyoe3bSWi73YA7xyNfpZ+4jXHw+kT7+s196xwoZO3OBmUMkHNqyXlbfN7i2xV54b8MvFO8l72PwDPr96cexNZL27t0rS5YskT179piSQYrg6+bz7y1Ufzf6LEyfiTVr1sj3v/99efXVV01J/Ij1z7YGH619irUgE/HvjgdqlgAAAADAA2EJAAAA/Xbw4EGZOHGimQPiE83wIqGfzfAQeaFqhofwC0UzPAQPzfAGIMab4fXWXEg7sWvfDEsv+KnDLq++/8vOdt3R/h7ax6KrM/2BE/NeujrPd3V6t/sfjKHSDO/hhx+W1157TR566CFTEj9ivRlerIrGZniEpUiIkT/oABBTCEthF+qwZIOSu1O6hqQ5137llOvZVJZ8IC//+DNOp/fA69zY0cA0MHktV/o4O9f+2VmHsNR3hCUEG32WAAAA+qh829tOjZB79C6tHfIKPD3p2sd42fP2X0zJqTSQTVl0s5kDgJMISwAAoFclJSXmXnj11NSuPzQM6RDJgde32ffu887tYGuTAMQnwhIAAOjVD3/4Qzn77LPl6aefNiWhp83tlF7PJfACnP1lw9D+90+9Fs2Gpx5wrh2D/tMmpXl5eWYOiE+EJQAA0CcbNmyQ5cuXhy00aXO7W3/7sdOEzl6AczChSUOR9k2ytK+T9lOaecVtpgT9lZ6ebu4B8YmwBABAmOkZeZ/PF5zJvz/P8iBP2pnfsqFp41P3S3trsykNHR38QUOT9j3S0DTQwFR8/jVOOLJN77QPU2CfqGDYs/5Zz3/DsE3+5+BZHuRJL0gLxDvCEgAAYaTXpdGBaIM2+ffpWR7k6XOf+1zXC/ArKCiQn/3sZzLnuq9KYnKqKQ09HdxBw427dqg/tKZKa6l2vfG003dJ+zBNumiZWRo8xQuu9/w3DNvkfw6e5SGY7rnnnq4XDcQpwhIAAOgTG5J02PPbb79dEpKSzZLwyhxVZO7139zlX3cGjdjy8kNOcJpw3tVmCQCcjrAEAAB69dWvfvVESBo2bJgpDR2t+dE+Su7R67T5nAadwdQG2XCktUoMFw6gN4QlAADQq3PPPTdkIUn7EWkwck9NtRXORWSfuevKE2XrfvMvTtlga4Ps6HdF8650bgGgO75ObXCK8PLFxlXmASCmDNVjawRf96V3rJCxMxeYOViHtqyX1fdF8LpN/M4YND7bkRHx744HapYAAAAAwANhCQAAAAA8EJYAAAAAwANhCQAAAAA8EJYAAAAAwAOj4UUCo9QAQPAxGl7YMWKYN0bDi3362Y5Ve9Y/K8ULrjdzsSfaRsMjLEUCBzEACD7CUtgRlrwRlhBJPv/7z8/74KEZHgAAAAB4ICwBAAAAgAfCEgAAAAB4ICwBAAAAgAfCEgAAAAB4ICwBAAAAgAfCEgAAAAB4ICwBAAAAgAfCEgAAAAB4ICwBAAAAgAfCEgAAAAB4ICwBAAAAgAfCEgAAAAB4ICwBAAAAgAfCEgAAAAB4ICwBAAAAgAfCEgAAAAB4ICwBAAAAgAfCEgAAAAB4ICwBAAAAgAfCEgAAAAB4ICwBAAAAgAdfp5+5j3Dx+cwdAEBQDcU/afo3JUKv+9I7Vph7CLT6vi+YexEQwc8EIs/nf//5eR88hCUAAGIZP4wRiM/EkEZYCi6a4QEAAACAB8ISAAAAAHggLAEAAACAB8ISAAAAAHggLAEAAACAB8ISAAAAAHggLAEAAACAB8ISAAAAAHggLAEAAACAB8ISAAAAAHggLAEAAACAB8ISAAAAAHggLAEAAACAB8ISAAAAAHggLAEAAACAB8ISAAAAAHggLAEAAACAB8ISAAAAAHggLAEAAACAB1+nn7kPAABijc9n7gAu/Lwbsnz+YwI/74OHsAQAAADECcJScNEMDwAAAAA8EJYAAAAAwANhCQAAAAA8EJYAAAAAwANhCQAAAAA8EJYAAAAAwANhCQAAAAA8EJYAAACAGLZhwwYpLi52JmXvazkGh7AEAAAAxLC5c+fKxIkTZe/evc683uq8lmNwCEsAAABAjLv77rvNvS6B8xgYwhIAAAAQ4xYvXuxMgfcxOIQlAAAAIA7Y2iRqlYLH1+ln7gMAAACIoCP1TVJ5tFHKj9RLVe0xaWhqlpa2DqmpOybS2Cji/+le29QqTceaRDo6pL2jUyobm51ytWndszJn4fXOffH5JD89VRITfCIJCZI2PE2y0pKdcklPl+wRwyUlyV+ekiyjczIkf2S6FORkSk5mWtf2ICwBAAAA4VJaVecPQg1SWdsoh/2B6PDhGqmsOCLlR49JZVObpEmHFLQ2Sn7jURldeUgyqg5Loj8U5TXUmD2IZDXVS1qLPyAZBXXV5t7pKjOzpd3X1ZisKSVVatMynfuqZvgIaUlKloa80VKVN0bKM7KlPDldGjoTpGB4kuRnDZeC0TkyenS25GV1Ban8kcOlaNRIs4f4R1gCAAAAQkCDUUlptWzde1h2bN8v2yv8Iae9VYqO10p+bbWMPnxARleUSr4/CBXUVUl+fY2ktZ4MQZGiAap8RK5UZuQ4t4dHFUqVfyofmS+laVnSkJAsk/MyZOrU8TKjuECmjc+TwrwRZuv4QlgCAAAABqm28bhs2u0PRQerZNe2fbKl7KiktLXItOqDMnXXxzKpbLfM9E9ZTQ1mi9jVkDpcto+eKLvGFMvWqWfJ9rxx0pCYItNGZcqMmcUytWiUE6C0WV+sIywBAAAA/dTU3CobdpXJWx+WyLub90p7sz8YHS2TqSWbZVJpSdwEo76qTcuQLWPO8AeoM2THpFmyPXecJKamyHmzJ8oFZ0+WuZPGSFpqslk7dhCWAAAAgD7Q2qO1G/fK2nUbZfvhOplWWy4XfbhWztv9kRQerTBrwSofkSfvnnGmvHHOJbJl5BiZVpAlF5w/SxadOTFmap0ISwAAAEA3NCCt27RP1rzuD0jltbLgwFa5+IM1Mm//lqjoXxQrtB/UhnHT5PV5S2TdhDlSlD9CFl04W5acfUZUj75HWAIAAAACbNlXIc+88oGs33rgRECav2+zpLS1mjUwUO0JCbK++Cx5/ZzFsn78DJk3tVBuvGKezCkebdaIHoQlAAAAwK+9o0NWf7hbnnzhHamtqpFlb70gV294VTKaj5k1EGw6WMSqWRfK0xdeJ4l5OXLz1efL0nmTJNEfqKIBYQkAAABDmoakV97fJY88u17yDx+Um//6R1mw+yOzFOHyzsTZ8tiSm6VyTJHcuuyiqAhNhCUAAAAMWa9t3CO/e/x1JyR99oX/krkHt5sliBTt2/RfS//WCU2fvXGhPzRNNkvCj7AEAACAIafyaKM8+D+rZf/WPXL7078kJEUhDU2/vP7LkjP1DLn9M5dLQU6GWRI+hCUAAAAMKa+8s11+/ae1ct17L8stbzzDoA1RTAeDeOKCa+XRBdfJ55ddKNctnGmWhAdhCQAAAENCS1u7PPg/r8qWtz+S7/7xPimuLjVLEO30mk3f+7t/laKzZ8qdn7ksbBe4JSwBAAAg7h2pb5Lv/PxpKfroXbnz6V9yjaQYpNdquv/6r8j2uRfIT25fHpbrMxGWAAAAENeamlvlH+/9o5z35kvy1VX/bUoRq55YcK08t/RTct+3bgp5YCIsAQAAIG5pUPrOf/xZpq55gaAUR2xg+sV3PikZaSmmNPii42pPAAAAQAj89ol1UvDum/EXlLS+45lnuu5//etd8w8+2DU/ULqP9evNTHS7af1KueDdv8ovH1tjSkKDsAQAAIC4tKGkTN54e4t87cWHTEmI7NjRFTTcU4yEjlj2+VcekS0fbJP1W/abkuAjLAEAACAu/foPL8s/vfCQZDQfMyUhtHOniM/XNS1aJHLBBV0hKhweeKDrcb/2NVPQC62B0kB38cWmwNB9LFhgZqKfDvmu18j65SOrTUnwEZYAAAAQd7bsq5Cmqhq5ZOf7piSMXn9d5NlnRaZMOT2QIKj0YsIZNVXyzraDpiS4CEsAAACIOy+t/kCWvfmcmYuA/aZp2Nlnd91WVXX1MbJN9ty1TrrM3YRP+yC52Zqg7pZrINPywD5L7m30MZQ+7j//c9f9tWu7ltm+T7pOYPNBnXfvJ7C2TJdrWeBzDGNIvGHt0/LyaxvNXHARlgAAABB3du2rkBllu81cBBQVdd1++GHXrbr+epGtW7uau02d2lWmweKNN0424fvFL0R+/vOTgUhvNdxouV1Hl/dG9/vWWye30cfQUKSPq/tS2lxQl91wQ9d8IA1B2pzQ7kOnnJyTwcvSGrQrrzy5jjZJfOopszD0ppXvlf2Hqs1ccBGWAAAAEHdKG1uloC7gR324aMDRYKRhRZvkWRoi3MFEw0u1/0e+u0z7HWnZLbd0zeutzrv7I2kg6YmtKXL3P9LH6C4UedHXoCHoG98wBcYPfiCSm3tq7ZY+Pxv+1Esvda0Tptql/IYaKW9sMXPBRVgCAABA3Gnv7JTEjg4zFwYaLGwTNK350dqbwMESNFS4jRrVFSrsdnbSMkv3qyGrP3S/gY/VX/q4yl0zpuy8Xe7FPl/bBDHEEjvazb3gIywBAAAg7hSmJ0vpSH9oCBf3aHg69XVkOg017u3sFEOj0kVaZWa2FAxPNnPBRVgCAABA3JlcmCsl+ePNXJSqqDi1FsnLkSOnr9Nb87be9tuXmqruaofsfH9ru0KoJL9ICkdnm7ngIiwBAAAg7lyx9Dx55qLrzFyU+o//6LoNHGFO522fIO3/o03e3CPd6Sh2PbH7dY9sp/2YbF8m65OfNHc86LWbtNbre98zBYY2MdSgpMujxDMLr5crlsw1c8FFWAIAAEDcmVM8Wtpzc+X9opmmJArp4A/a5M7d30knDUg2jGhzPr1mk46IZ5frKHY99UnS/doL49ptLrro5AAPum8dfMLuM3DIcSsvr6tmy+5DJ93OPZhDhG0fPVHK88bI/OnjTElw+Tr9zH0AAAAgbqzftEce/PWzsuI335a01mZTinjRnpAg//jlH8utX1oml5wz2ZQGFzVLAAAAiEsL5hTL3LlT5fdLPmVKEE/+c/EnpfCsGSELSoqwBAAAgLj1T7deJu9esFSeWHCtKUE80Pdz7cJr5PbPXGZKQoOwBAAAgLiVkZYi933rJnluyU3yxLlXmlLEMn0fH714ufO+ZqUPM6WhQZ8lAAAAxL0j9U3yjR//SeZueEO+9tLDktLWapYgVmgfpd9e9rey9rzL5EffWCZFo0aaJaFDWAIAAMCQ0NTcKj/9/YtS+sFm+cFjP5H8hhqzBNGuMiNb/r+bb5eUM+fId//hGqfGMBwISwAAABhSnnjlA/nvF96Tv3v9SVn2wSuS2NFhliAa/eXMS+R3l/2tfHLp2XLLJ84zpeFBWAIAAMCQU1pVJz9d8YK0lOyWrz33G5l2eK9ZgmhRkj9eHrz2S9I+abL8ry99IizN7gIRlgAAADBkvfj2dvndE+tk5sEd8tlVj8rkygNmCSJFQ9J/XX6LbBk3Vf7++gVy9YXTJTEhMuPSEZYAAAAwpLW0tctz67bIo8+/44Smm9c+JXNKd5qlCJftoyfKI5d+0glJt1w9X65bOFNSkhLN0sggLAEAAAB+Tmh6c5s8/fJ7klZTLdete06u3PIGI+eFUEtSsrw2ZZ48ufgmqR2ZKzddcW5UhCSLsAQAAAAEeGfbQXnm5fdl097DcsmejbL4gzUyb/8WsxSDtalwiqydc5Gsmn6BTCvKl2svnycLZo2PWHO77hCWAAAAgG6UH2mQVe+XyNr1H0ttTZ0s2vaOLNr0hsws28Uoev1kA9La6fMlKytDFi2YJUvmTZbCvBFmjehDWAIAAAD6QEfQe9UfnN56Z6vsP3pM5pftlHM/elPm790sOY21Zi1YtWkZ8s7E2fLeWQvlnTFTpGDkcLno/JlRH5DcCEsAAABAP9U2Hnea6r33wU55Z8chyWlplMkVB2Tqjo0y9fBe//39ktbabNaOf9r3aE9uoWwdc4bsmjJHthcUS3lKusyfXCDnzpsm86ePk5zMNLN27CAsAQAAAIO0p6xGSg5Vy47dZbJ16z4pOXpcilobZNrBnTJp7zaZUbZbiqtL42KwiFOC0cTpsr1wspQOGyFFmSkyY+p4mTq5UKaNy5PiMdlmi9hFWAIAAACCrL2jwwlQ2w9UybYdB2T7rkOyv75FiprrpKC+WvKqyqWgolTyGmqkoK7KP1VHVVO+I+lZUj4iVyozsuXwiDypzB8jh/PHSnlmruxJzZLizGSZNmmsTDpjrMyYMEomF+ZE3eAMwUBYAgAAAMJAhyYvKa2WyqONcvhIg1RW18rhQ5VSWdMg5Q0t0tAuUtBxXPKP10vB0UoZXXHQP5WarUXSWo5LVlODmRPJ9wctO8hESnvrKWFLw05LYrJzv90fYjT0WNqXqCllmJkTOTyq0D+Nk8qsXClPy5LKhFRJS/RJQUaK5GdnyOix+ZKfmyWjczIkf2S6FBdkS1pq177jHWEJAAAAiAIapsqP1PvD1DHntqq2K1RJS4szNbW2O32lpLWrKV/lsVZpb2tz7rf4M9ORrruOnCR/gDIVPYlJSZI/3ISblBTJSPNPKf4VUlNFkpOdEJSXlS4FOZn+MDTcuY2W6xxFGmEJAAAAADzEX8NCAAAAAAgCwhIAAAAAeCAsAQAAAIAHwhIAAAAAeCAsAQAAAIAHwhIAAAAAeCAsAQAAAIAHwhIAAAAAeCAsAQAAAIAHwhIAAAAAeCAsAQAAAIAHwhIAAAAAeCAsAQAAAIAHwhIAAAAAeCAsAQAAAIAHwhIAAAAAeCAsAQAAAIAHwhIAAAAAeCAsAQAAAIAHwhIAAAAAeCAsAQAAAIAHwhIAAAAAeCAsAQAAAIAHwhIAAAAAeCAsAQAAAIAHwhIAAAAAeCAsAQAAAIAHwhIAAAAAeCAsAQAAAIAHwhIAAAAAeCAsAQAAAMBpRP4fR8TweuA+8a8AAAAASUVORK5CYII="
     }
    },
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![wine_review_pipeline.png](attachment:wine_review_pipeline.png)"
+    "![final_model_workflow.png](attachment:final_model_workflow.png)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.044132,
-     "end_time": "2020-11-13T16:26:54.645093",
+     "duration": 0.052736,
+     "end_time": "2020-11-14T07:16:32.973866",
      "exception": false,
-     "start_time": "2020-11-13T16:26:54.600961",
+     "start_time": "2020-11-14T07:16:32.921130",
      "status": "completed"
     },
     "tags": []
@@ -552,16 +554,16 @@
    "execution_count": 18,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-13T16:26:54.747138Z",
-     "iopub.status.busy": "2020-11-13T16:26:54.746523Z",
-     "iopub.status.idle": "2020-11-13T16:26:56.767433Z",
-     "shell.execute_reply": "2020-11-13T16:26:56.766316Z"
+     "iopub.execute_input": "2020-11-14T07:16:33.088802Z",
+     "iopub.status.busy": "2020-11-14T07:16:33.088006Z",
+     "iopub.status.idle": "2020-11-14T07:16:35.282028Z",
+     "shell.execute_reply": "2020-11-14T07:16:35.282879Z"
     },
     "papermill": {
-     "duration": 2.070739,
-     "end_time": "2020-11-13T16:26:56.767589",
+     "duration": 2.254509,
+     "end_time": "2020-11-14T07:16:35.283092",
      "exception": false,
-     "start_time": "2020-11-13T16:26:54.696850",
+     "start_time": "2020-11-14T07:16:33.028583",
      "status": "completed"
     },
     "tags": []
@@ -576,16 +578,16 @@
    "execution_count": 19,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-13T16:26:56.862983Z",
-     "iopub.status.busy": "2020-11-13T16:26:56.862188Z",
-     "iopub.status.idle": "2020-11-13T16:26:57.899455Z",
-     "shell.execute_reply": "2020-11-13T16:26:57.898940Z"
+     "iopub.execute_input": "2020-11-14T07:16:35.488768Z",
+     "iopub.status.busy": "2020-11-14T07:16:35.487763Z",
+     "iopub.status.idle": "2020-11-14T07:16:36.933536Z",
+     "shell.execute_reply": "2020-11-14T07:16:36.932943Z"
     },
     "papermill": {
-     "duration": 1.086016,
-     "end_time": "2020-11-13T16:26:57.899587",
+     "duration": 1.531913,
+     "end_time": "2020-11-14T07:16:36.933669",
      "exception": false,
-     "start_time": "2020-11-13T16:26:56.813571",
+     "start_time": "2020-11-14T07:16:35.401756",
      "status": "completed"
     },
     "tags": []
@@ -601,16 +603,16 @@
    "execution_count": 20,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-13T16:26:57.992894Z",
-     "iopub.status.busy": "2020-11-13T16:26:57.992222Z",
-     "iopub.status.idle": "2020-11-13T16:26:57.996411Z",
-     "shell.execute_reply": "2020-11-13T16:26:57.995888Z"
+     "iopub.execute_input": "2020-11-14T07:16:37.050094Z",
+     "iopub.status.busy": "2020-11-14T07:16:37.049269Z",
+     "iopub.status.idle": "2020-11-14T07:16:37.053491Z",
+     "shell.execute_reply": "2020-11-14T07:16:37.052930Z"
     },
     "papermill": {
-     "duration": 0.051834,
-     "end_time": "2020-11-13T16:26:57.996514",
+     "duration": 0.06368,
+     "end_time": "2020-11-14T07:16:37.053609",
      "exception": false,
-     "start_time": "2020-11-13T16:26:57.944680",
+     "start_time": "2020-11-14T07:16:36.989929",
      "status": "completed"
     },
     "tags": []
@@ -625,22 +627,23 @@
    "execution_count": 21,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-13T16:26:58.093284Z",
-     "iopub.status.busy": "2020-11-13T16:26:58.092386Z",
-     "iopub.status.idle": "2020-11-13T16:26:58.836966Z",
-     "shell.execute_reply": "2020-11-13T16:26:58.837751Z"
+     "iopub.execute_input": "2020-11-14T07:16:37.168143Z",
+     "iopub.status.busy": "2020-11-14T07:16:37.167109Z",
+     "iopub.status.idle": "2020-11-14T07:16:37.905300Z",
+     "shell.execute_reply": "2020-11-14T07:16:37.906575Z"
     },
     "papermill": {
-     "duration": 0.795514,
-     "end_time": "2020-11-13T16:26:58.837942",
+     "duration": 0.798289,
+     "end_time": "2020-11-14T07:16:37.906760",
      "exception": false,
-     "start_time": "2020-11-13T16:26:58.042428",
+     "start_time": "2020-11-14T07:16:37.108471",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [],
    "source": [
+    "# downloading yoast_stop_words to be included to spacy's stop words to improve performance\n",
     "response = requests.get('https://raw.github.com/Yoast/YoastSEO.js/develop/src/config/stopwords.js')\n",
     "yoast_stop_words = response.content.decode()"
    ]
@@ -650,16 +653,16 @@
    "execution_count": 22,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-13T16:26:58.996104Z",
-     "iopub.status.busy": "2020-11-13T16:26:58.992100Z",
-     "iopub.status.idle": "2020-11-13T16:26:59.001020Z",
-     "shell.execute_reply": "2020-11-13T16:26:58.999960Z"
+     "iopub.execute_input": "2020-11-14T07:16:38.070550Z",
+     "iopub.status.busy": "2020-11-14T07:16:38.069609Z",
+     "iopub.status.idle": "2020-11-14T07:16:38.077257Z",
+     "shell.execute_reply": "2020-11-14T07:16:38.078018Z"
     },
     "papermill": {
-     "duration": 0.093147,
-     "end_time": "2020-11-13T16:26:59.001220",
+     "duration": 0.094878,
+     "end_time": "2020-11-14T07:16:38.078257",
      "exception": false,
-     "start_time": "2020-11-13T16:26:58.908073",
+     "start_time": "2020-11-14T07:16:37.983379",
      "status": "completed"
     },
     "tags": []
@@ -685,16 +688,16 @@
    "execution_count": 23,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-13T16:26:59.152144Z",
-     "iopub.status.busy": "2020-11-13T16:26:59.151300Z",
-     "iopub.status.idle": "2020-11-13T16:26:59.158105Z",
-     "shell.execute_reply": "2020-11-13T16:26:59.159273Z"
+     "iopub.execute_input": "2020-11-14T07:16:38.247024Z",
+     "iopub.status.busy": "2020-11-14T07:16:38.246057Z",
+     "iopub.status.idle": "2020-11-14T07:16:38.255578Z",
+     "shell.execute_reply": "2020-11-14T07:16:38.256338Z"
     },
     "papermill": {
-     "duration": 0.088057,
-     "end_time": "2020-11-13T16:26:59.159555",
+     "duration": 0.097452,
+     "end_time": "2020-11-14T07:16:38.256538",
      "exception": false,
-     "start_time": "2020-11-13T16:26:59.071498",
+     "start_time": "2020-11-14T07:16:38.159086",
      "status": "completed"
     },
     "tags": []
@@ -706,7 +709,7 @@
      "text": [
       "length of yoast_stop_words is 153\n",
       "\n",
-      "{'him', \"here's\", 'this', 'could', 'had', 'few', 'below', 'be', 'himself', 'or', \"let's\", 'on', 'our', 'too', \"she's\", 'we', \"we'd\", 'having', 'to', 'was', 'against', 'each', \"he'd\", 'myself', 'there', 'they', 'until', \"we're\", 'itself', 'he', \"he'll\", 'does', 'further', 'did', 'for', 'of', 'it', 'through', 'where', 'those', 'what', 'yours', 'an', \"how's\", 'some', 'with', 'whom', 'at', 'are', 'once', \"he's\", 'and', \"you'll\", 'as', \"we've\", 'about', 'being', \"that's\", 'from', 'all', 'any', \"i'll\", 'then', \"they'll\", \"you're\", \"you've\", 'why', 'herself', 'i', \"there's\", 'how', 'by', 'his', 'were', 'you', 'again', \"when's\", 'more', 'her', 'in', 'while', 'because', 'which', 'doing', 'nor', \"she'll\", 'been', 'over', 'their', \"we'll\", \"why's\", 'than', 'other', 'should', \"she'd\", 'am', 'down', 'them', 'ourselves', 'ours', \"you'd\", \"i'd\", 'such', 'that', 'themselves', 'both', \"where's\", 'but', 'the', 'has', 'up', 'hers', 'would', 'have', 'during', 'before', 'me', 'same', 'your', 'under', 'above', \"i'm\", 'most', 'yourselves', 'between', 'my', 'into', \"who's\", 'these', 'yourself', 'very', 'its', 'is', 'after', 'own', 'who', \"what's\", \"they've\", 'do', 'if', 'out', \"they'd\", \"they're\", 'ought', 'theirs', 'here', \"i've\", 'only', 'so', 'she', 'a', 'when', \"it's\"}\n"
+      "{'own', 'down', 'only', 'and', 'than', 'after', 'themselves', 'of', 'could', \"i'll\", 'itself', 'this', 'while', 'they', 'with', 'once', 'she', 'as', 'nor', 'himself', 'more', 'then', 'being', 'your', \"they'll\", 'into', 'here', \"he'd\", 'against', 'on', 'whom', \"you'll\", 'ourselves', 'such', \"here's\", 'theirs', 'ours', \"who's\", \"you're\", 'these', 'were', 'yours', 'few', 'from', \"how's\", 'its', 'is', \"you'd\", 'between', \"he's\", \"that's\", 'it', 'very', 'yourselves', \"they've\", 'where', \"i'm\", 'because', 'their', 'does', 'did', 'that', 'an', 'ought', 'other', 'the', \"she'd\", 'what', 'would', 'be', 'have', 'are', 'same', 'my', \"he'll\", \"i'd\", 'below', 'in', \"they're\", 'or', 'when', 'should', 'each', 'who', 'to', 'doing', 'too', 'so', 'had', 'our', 'some', 'herself', 'been', 'out', 'by', 'further', 'her', 'how', 'about', 'but', 'he', \"we've\", 'both', 'having', 'above', \"she's\", 'his', \"there's\", 'over', \"why's\", 'am', 'do', 'before', 'under', \"you've\", \"it's\", 'up', 'him', \"we'll\", 'until', 'yourself', 'at', 'through', \"where's\", \"she'll\", 'which', \"when's\", 'hers', 'has', 'was', 'any', 'during', 'them', 'we', \"what's\", 'a', 'i', 'for', \"we're\", \"we'd\", 'those', \"i've\", 'myself', 'me', \"they'd\", 'again', \"let's\", 'you', 'most', 'why', 'all', 'if', 'there'}\n"
      ]
     }
    ],
@@ -723,16 +726,16 @@
    "execution_count": 24,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-13T16:26:59.320457Z",
-     "iopub.status.busy": "2020-11-13T16:26:59.319569Z",
-     "iopub.status.idle": "2020-11-13T16:26:59.340450Z",
-     "shell.execute_reply": "2020-11-13T16:26:59.341601Z"
+     "iopub.execute_input": "2020-11-14T07:16:38.421188Z",
+     "iopub.status.busy": "2020-11-14T07:16:38.405891Z",
+     "iopub.status.idle": "2020-11-14T07:16:38.423608Z",
+     "shell.execute_reply": "2020-11-14T07:16:38.424069Z"
     },
     "papermill": {
-     "duration": 0.112667,
-     "end_time": "2020-11-13T16:26:59.341769",
+     "duration": 0.089621,
+     "end_time": "2020-11-14T07:16:38.424218",
      "exception": false,
-     "start_time": "2020-11-13T16:26:59.229102",
+     "start_time": "2020-11-14T07:16:38.334597",
      "status": "completed"
     },
     "tags": []
@@ -748,16 +751,16 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.062816,
-     "end_time": "2020-11-13T16:26:59.467118",
+     "duration": 0.054957,
+     "end_time": "2020-11-14T07:16:38.533669",
      "exception": false,
-     "start_time": "2020-11-13T16:26:59.404302",
+     "start_time": "2020-11-14T07:16:38.478712",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "### creating custom transformers to encapsulate our preprocessing"
+    "## Creating custom transformers to encapsulate our data preprocessing"
    ]
   },
   {
@@ -765,16 +768,16 @@
    "execution_count": 25,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-13T16:26:59.596960Z",
-     "iopub.status.busy": "2020-11-13T16:26:59.596116Z",
-     "iopub.status.idle": "2020-11-13T16:26:59.599459Z",
-     "shell.execute_reply": "2020-11-13T16:26:59.598877Z"
+     "iopub.execute_input": "2020-11-14T07:16:38.655640Z",
+     "iopub.status.busy": "2020-11-14T07:16:38.654831Z",
+     "iopub.status.idle": "2020-11-14T07:16:38.658509Z",
+     "shell.execute_reply": "2020-11-14T07:16:38.657917Z"
     },
     "papermill": {
-     "duration": 0.069515,
-     "end_time": "2020-11-13T16:26:59.599637",
+     "duration": 0.068061,
+     "end_time": "2020-11-14T07:16:38.658618",
      "exception": false,
-     "start_time": "2020-11-13T16:26:59.530122",
+     "start_time": "2020-11-14T07:16:38.590557",
      "status": "completed"
     },
     "tags": []
@@ -805,16 +808,16 @@
    "execution_count": 26,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-13T16:26:59.760003Z",
-     "iopub.status.busy": "2020-11-13T16:26:59.759054Z",
-     "iopub.status.idle": "2020-11-13T16:26:59.761557Z",
-     "shell.execute_reply": "2020-11-13T16:26:59.760855Z"
+     "iopub.execute_input": "2020-11-14T07:16:38.774599Z",
+     "iopub.status.busy": "2020-11-14T07:16:38.772987Z",
+     "iopub.status.idle": "2020-11-14T07:16:38.775707Z",
+     "shell.execute_reply": "2020-11-14T07:16:38.776249Z"
     },
     "papermill": {
-     "duration": 0.101514,
-     "end_time": "2020-11-13T16:26:59.761685",
+     "duration": 0.062337,
+     "end_time": "2020-11-14T07:16:38.776409",
      "exception": false,
-     "start_time": "2020-11-13T16:26:59.660171",
+     "start_time": "2020-11-14T07:16:38.714072",
      "status": "completed"
     },
     "tags": []
@@ -829,10 +832,10 @@
    "execution_count": null,
    "metadata": {
     "papermill": {
-     "duration": 0.073495,
-     "end_time": "2020-11-13T16:26:59.897720",
+     "duration": 0.05586,
+     "end_time": "2020-11-14T07:16:38.887419",
      "exception": false,
-     "start_time": "2020-11-13T16:26:59.824225",
+     "start_time": "2020-11-14T07:16:38.831559",
      "status": "completed"
     },
     "tags": []
@@ -845,16 +848,16 @@
    "execution_count": 27,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-13T16:27:00.000095Z",
-     "iopub.status.busy": "2020-11-13T16:26:59.998699Z",
-     "iopub.status.idle": "2020-11-13T16:27:00.000957Z",
-     "shell.execute_reply": "2020-11-13T16:27:00.001677Z"
+     "iopub.execute_input": "2020-11-14T07:16:39.007485Z",
+     "iopub.status.busy": "2020-11-14T07:16:39.006591Z",
+     "iopub.status.idle": "2020-11-14T07:16:39.009177Z",
+     "shell.execute_reply": "2020-11-14T07:16:39.009707Z"
     },
     "papermill": {
-     "duration": 0.056632,
-     "end_time": "2020-11-13T16:27:00.001813",
+     "duration": 0.066876,
+     "end_time": "2020-11-14T07:16:39.009848",
      "exception": false,
-     "start_time": "2020-11-13T16:26:59.945181",
+     "start_time": "2020-11-14T07:16:38.942972",
      "status": "completed"
     },
     "tags": []
@@ -880,16 +883,16 @@
    "execution_count": 28,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-13T16:27:00.101193Z",
-     "iopub.status.busy": "2020-11-13T16:27:00.099297Z",
-     "iopub.status.idle": "2020-11-13T16:27:00.102044Z",
-     "shell.execute_reply": "2020-11-13T16:27:00.102527Z"
+     "iopub.execute_input": "2020-11-14T07:16:39.128126Z",
+     "iopub.status.busy": "2020-11-14T07:16:39.127248Z",
+     "iopub.status.idle": "2020-11-14T07:16:39.131524Z",
+     "shell.execute_reply": "2020-11-14T07:16:39.130930Z"
     },
     "papermill": {
-     "duration": 0.054246,
-     "end_time": "2020-11-13T16:27:00.102674",
+     "duration": 0.063939,
+     "end_time": "2020-11-14T07:16:39.131636",
      "exception": false,
-     "start_time": "2020-11-13T16:27:00.048428",
+     "start_time": "2020-11-14T07:16:39.067697",
      "status": "completed"
     },
     "tags": []
@@ -904,10 +907,10 @@
    "execution_count": null,
    "metadata": {
     "papermill": {
-     "duration": 0.047322,
-     "end_time": "2020-11-13T16:27:00.197064",
+     "duration": 0.099082,
+     "end_time": "2020-11-14T07:16:39.286767",
      "exception": false,
-     "start_time": "2020-11-13T16:27:00.149742",
+     "start_time": "2020-11-14T07:16:39.187685",
      "status": "completed"
     },
     "tags": []
@@ -920,16 +923,16 @@
    "execution_count": 29,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-13T16:27:00.298617Z",
-     "iopub.status.busy": "2020-11-13T16:27:00.297873Z",
-     "iopub.status.idle": "2020-11-13T16:27:00.301682Z",
-     "shell.execute_reply": "2020-11-13T16:27:00.301147Z"
+     "iopub.execute_input": "2020-11-14T07:16:39.411138Z",
+     "iopub.status.busy": "2020-11-14T07:16:39.410239Z",
+     "iopub.status.idle": "2020-11-14T07:16:39.414330Z",
+     "shell.execute_reply": "2020-11-14T07:16:39.413785Z"
     },
     "papermill": {
-     "duration": 0.057352,
-     "end_time": "2020-11-13T16:27:00.301792",
+     "duration": 0.068186,
+     "end_time": "2020-11-14T07:16:39.414453",
      "exception": false,
-     "start_time": "2020-11-13T16:27:00.244440",
+     "start_time": "2020-11-14T07:16:39.346267",
      "status": "completed"
     },
     "tags": []
@@ -953,16 +956,16 @@
    "execution_count": 30,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-13T16:27:00.400054Z",
-     "iopub.status.busy": "2020-11-13T16:27:00.399136Z",
-     "iopub.status.idle": "2020-11-13T16:27:00.401864Z",
-     "shell.execute_reply": "2020-11-13T16:27:00.402477Z"
+     "iopub.execute_input": "2020-11-14T07:16:39.535092Z",
+     "iopub.status.busy": "2020-11-14T07:16:39.533027Z",
+     "iopub.status.idle": "2020-11-14T07:16:39.535903Z",
+     "shell.execute_reply": "2020-11-14T07:16:39.536450Z"
     },
     "papermill": {
-     "duration": 0.053638,
-     "end_time": "2020-11-13T16:27:00.402622",
+     "duration": 0.064796,
+     "end_time": "2020-11-14T07:16:39.536584",
      "exception": false,
-     "start_time": "2020-11-13T16:27:00.348984",
+     "start_time": "2020-11-14T07:16:39.471788",
      "status": "completed"
     },
     "tags": []
@@ -977,10 +980,10 @@
    "execution_count": null,
    "metadata": {
     "papermill": {
-     "duration": 0.046676,
-     "end_time": "2020-11-13T16:27:00.498314",
+     "duration": 0.058075,
+     "end_time": "2020-11-14T07:16:39.651083",
      "exception": false,
-     "start_time": "2020-11-13T16:27:00.451638",
+     "start_time": "2020-11-14T07:16:39.593008",
      "status": "completed"
     },
     "tags": []
@@ -993,16 +996,16 @@
    "execution_count": 31,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-13T16:27:00.606993Z",
-     "iopub.status.busy": "2020-11-13T16:27:00.606022Z",
-     "iopub.status.idle": "2020-11-13T16:27:00.609180Z",
-     "shell.execute_reply": "2020-11-13T16:27:00.608574Z"
+     "iopub.execute_input": "2020-11-14T07:16:39.773323Z",
+     "iopub.status.busy": "2020-11-14T07:16:39.771308Z",
+     "iopub.status.idle": "2020-11-14T07:16:39.774327Z",
+     "shell.execute_reply": "2020-11-14T07:16:39.774896Z"
     },
     "papermill": {
-     "duration": 0.061172,
-     "end_time": "2020-11-13T16:27:00.609284",
+     "duration": 0.06594,
+     "end_time": "2020-11-14T07:16:39.775030",
      "exception": false,
-     "start_time": "2020-11-13T16:27:00.548112",
+     "start_time": "2020-11-14T07:16:39.709090",
      "status": "completed"
     },
     "tags": []
@@ -1013,13 +1016,75 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-11-14T07:16:39.916743Z",
+     "iopub.status.busy": "2020-11-14T07:16:39.915655Z",
+     "iopub.status.idle": "2020-11-14T07:16:40.014696Z",
+     "shell.execute_reply": "2020-11-14T07:16:40.014090Z"
+    },
+    "papermill": {
+     "duration": 0.182177,
+     "end_time": "2020-11-14T07:16:40.014822",
+     "exception": false,
+     "start_time": "2020-11-14T07:16:39.832645",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "le = LabelEncoder()\n",
+    "one_hot = OneHotEncoder(sparse=False) \n",
+    "        \n",
+    "encoded_labels = le.fit_transform(labels)\n",
+    "one_hot_labels = one_hot.fit_transform(encoded_labels.reshape(-1, 1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-11-14T07:16:40.159199Z",
+     "iopub.status.busy": "2020-11-14T07:16:40.143751Z",
+     "iopub.status.idle": "2020-11-14T07:17:58.331804Z",
+     "shell.execute_reply": "2020-11-14T07:17:58.330799Z"
+    },
+    "papermill": {
+     "duration": 78.259564,
+     "end_time": "2020-11-14T07:17:58.331977",
+     "exception": false,
+     "start_time": "2020-11-14T07:16:40.072413",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[Pipeline] ........ (step 1 of 3) Processing get_tokens, total= 1.2min\n",
+      "[Pipeline] ... (step 2 of 3) Processing text_2_sequence, total=   6.4s\n",
+      "[Pipeline] ........... (step 3 of 3) Processing padding, total=   1.8s\n"
+     ]
+    }
+   ],
+   "source": [
+    "X_prep = data_prep_pipe.fit_transform(sent_oversample_corpus) # getting processed corpus"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.049582,
-     "end_time": "2020-11-13T16:27:00.706656",
+     "duration": 0.060684,
+     "end_time": "2020-11-14T07:17:58.456443",
      "exception": false,
-     "start_time": "2020-11-13T16:27:00.657074",
+     "start_time": "2020-11-14T07:17:58.395759",
      "status": "completed"
     },
     "tags": []
@@ -1030,25 +1095,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 34,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-13T16:27:00.808773Z",
-     "iopub.status.busy": "2020-11-13T16:27:00.807806Z",
-     "iopub.status.idle": "2020-11-13T16:27:00.810322Z",
-     "shell.execute_reply": "2020-11-13T16:27:00.810914Z"
+     "iopub.execute_input": "2020-11-14T07:17:58.579337Z",
+     "iopub.status.busy": "2020-11-14T07:17:58.578491Z",
+     "iopub.status.idle": "2020-11-14T07:17:58.582554Z",
+     "shell.execute_reply": "2020-11-14T07:17:58.581920Z"
     },
     "papermill": {
-     "duration": 0.057463,
-     "end_time": "2020-11-13T16:27:00.811070",
+     "duration": 0.068715,
+     "end_time": "2020-11-14T07:17:58.582669",
      "exception": false,
-     "start_time": "2020-11-13T16:27:00.753607",
+     "start_time": "2020-11-14T07:17:58.513954",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [],
    "source": [
+    "# defining a function to return the emdedding matrix of our word2vec\n",
     "def get_embedding_matrix(model, word_index):\n",
     "    vocab_size = len(word_index) + 1\n",
     "    embedding_dim = model.wv.vector_size\n",
@@ -1063,25 +1129,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 35,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-13T16:27:00.918563Z",
-     "iopub.status.busy": "2020-11-13T16:27:00.917507Z",
-     "iopub.status.idle": "2020-11-13T16:27:00.919987Z",
-     "shell.execute_reply": "2020-11-13T16:27:00.920668Z"
+     "iopub.execute_input": "2020-11-14T07:17:58.717662Z",
+     "iopub.status.busy": "2020-11-14T07:17:58.715537Z",
+     "iopub.status.idle": "2020-11-14T07:17:58.718399Z",
+     "shell.execute_reply": "2020-11-14T07:17:58.718905Z"
     },
     "papermill": {
-     "duration": 0.061628,
-     "end_time": "2020-11-13T16:27:00.920800",
+     "duration": 0.077192,
+     "end_time": "2020-11-14T07:17:58.719029",
      "exception": false,
-     "start_time": "2020-11-13T16:27:00.859172",
+     "start_time": "2020-11-14T07:17:58.641837",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [],
    "source": [
+    "# defining a custom keras multi-class fbeta function\n",
     "def multi_class_fbeta(ytrue , ypred, beta=1, weighted=True, raw=False, epsilon=1e-7):\n",
     "    beta_squared = beta**2\n",
     "\n",
@@ -1112,19 +1179,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 36,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-13T16:27:01.026113Z",
-     "iopub.status.busy": "2020-11-13T16:27:01.025328Z",
-     "iopub.status.idle": "2020-11-13T16:27:01.029385Z",
-     "shell.execute_reply": "2020-11-13T16:27:01.028812Z"
+     "iopub.execute_input": "2020-11-14T07:17:58.846855Z",
+     "iopub.status.busy": "2020-11-14T07:17:58.845915Z",
+     "iopub.status.idle": "2020-11-14T07:17:58.849708Z",
+     "shell.execute_reply": "2020-11-14T07:17:58.849035Z"
     },
     "papermill": {
-     "duration": 0.060831,
-     "end_time": "2020-11-13T16:27:01.029497",
+     "duration": 0.071064,
+     "end_time": "2020-11-14T07:17:58.849826",
      "exception": false,
-     "start_time": "2020-11-13T16:27:00.968666",
+     "start_time": "2020-11-14T07:17:58.778762",
      "status": "completed"
     },
     "tags": []
@@ -1149,7 +1216,7 @@
     "    model.add(Dense(20, activation='softmax'))\n",
     "\n",
     "    model.compile(optimizer='adam',\n",
-    "              loss='categorical_crossentropy',\n",
+    "              loss='sparse_categorical_crossentropy',\n",
     "              metrics=['accuracy', multi_class_fbeta])\n",
     "\n",
     "    return model"
@@ -1157,19 +1224,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 37,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-13T16:27:01.171585Z",
-     "iopub.status.busy": "2020-11-13T16:27:01.170891Z",
-     "iopub.status.idle": "2020-11-13T16:27:01.174637Z",
-     "shell.execute_reply": "2020-11-13T16:27:01.175109Z"
+     "iopub.execute_input": "2020-11-14T07:17:58.974467Z",
+     "iopub.status.busy": "2020-11-14T07:17:58.973595Z",
+     "iopub.status.idle": "2020-11-14T07:17:58.977438Z",
+     "shell.execute_reply": "2020-11-14T07:17:58.976896Z"
     },
     "papermill": {
-     "duration": 0.097695,
-     "end_time": "2020-11-13T16:27:01.175248",
+     "duration": 0.070876,
+     "end_time": "2020-11-14T07:17:58.977550",
      "exception": false,
-     "start_time": "2020-11-13T16:27:01.077553",
+     "start_time": "2020-11-14T07:17:58.906674",
      "status": "completed"
     },
     "tags": []
@@ -1185,30 +1252,73 @@
     "                           trainable=False))\n",
     "    \n",
     "    model.add(Dropout(0.5))\n",
-    "    model.add(Bidirectional(LSTM(250)))\n",
+    "    model.add(Bidirectional(LSTM(300)))\n",
     "    model.add(Dropout(0.5))\n",
     "    model.add(Dense(20, activation='softmax'))\n",
     "\n",
-    "    model.compile(loss='categorical_crossentropy',optimizer='adam',metrics=['accuracy', multi_class_fbeta])\n",
+    "    model.compile(loss='sparse_categorical_crossentropy', optimizer='adam', \\\n",
+    "                  metrics=['accuracy', multi_class_fbeta])\n",
     "\n",
     "    return model"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 38,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-13T16:27:01.291542Z",
-     "iopub.status.busy": "2020-11-13T16:27:01.289722Z",
-     "iopub.status.idle": "2020-11-13T16:27:01.292265Z",
-     "shell.execute_reply": "2020-11-13T16:27:01.292798Z"
+     "iopub.execute_input": "2020-11-14T07:17:59.150231Z",
+     "iopub.status.busy": "2020-11-14T07:17:59.149185Z",
+     "iopub.status.idle": "2020-11-14T07:17:59.163507Z",
+     "shell.execute_reply": "2020-11-14T07:17:59.162923Z"
     },
     "papermill": {
-     "duration": 0.070319,
-     "end_time": "2020-11-13T16:27:01.292928",
+     "duration": 0.126982,
+     "end_time": "2020-11-14T07:17:59.163635",
      "exception": false,
-     "start_time": "2020-11-13T16:27:01.222609",
+     "start_time": "2020-11-14T07:17:59.036653",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# setting class weights due to class imbalance\n",
+    "class_weights = class_weight.compute_class_weight('balanced', np.arange(20), encoded_labels)\n",
+    "class_weights = dict(enumerate(class_weights))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "papermill": {
+     "duration": 0.058848,
+     "end_time": "2020-11-14T07:17:59.283563",
+     "exception": false,
+     "start_time": "2020-11-14T07:17:59.224715",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Disguising CNN and LSTM models as transformers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-11-14T07:17:59.421162Z",
+     "iopub.status.busy": "2020-11-14T07:17:59.420253Z",
+     "iopub.status.idle": "2020-11-14T07:17:59.423731Z",
+     "shell.execute_reply": "2020-11-14T07:17:59.423136Z"
+    },
+    "papermill": {
+     "duration": 0.078923,
+     "end_time": "2020-11-14T07:17:59.423853",
+     "exception": false,
+     "start_time": "2020-11-14T07:17:59.344930",
      "status": "completed"
     },
     "tags": []
@@ -1216,8 +1326,9 @@
    "outputs": [],
    "source": [
     "class NLPModel(BaseEstimator, TransformerMixin):\n",
-    "    def __init__(self, build_fn, epochs=7, batch_size=128, verbose=0):\n",
+    "    def __init__(self, build_fn, name, epochs=7, batch_size=128, verbose=0):\n",
     "        self.build_fn = build_fn\n",
+    "        self.name = name\n",
     "        self.epochs = epochs\n",
     "        self.batch_size = batch_size\n",
     "        self.verbose = verbose\n",
@@ -1227,10 +1338,7 @@
     "        \n",
     "        t1 = time.time()\n",
     "        self.w2v_model = Word2Vec(self.corpus, size=300, min_count=1, iter=10)\n",
-    "        \n",
-    "        self.name = [k for k, v in union.transformer_list if v == self][0]\n",
-    "\n",
-    "        \n",
+    "                \n",
     "        print('Done training Word2Vec for {}                    total: {}mins'.format(self.name, \\\n",
     "                                                                          round((time.time()-t1)/60, 1)))\n",
     "        \n",
@@ -1239,20 +1347,10 @@
     "        \n",
     "        self.model = self.build_fn(self.embedding_matrix, X.shape[1])\n",
     "        \n",
-    "        self.le = LabelEncoder()\n",
-    "        self.one_hot = OneHotEncoder(sparse=False) \n",
-    "        \n",
-    "        self.encoded_labels = self.le.fit_transform(y)\n",
-    "        \n",
-    "        self.class_weights = class_weight.compute_class_weight('balanced', np.arange(20), self.encoded_labels)\n",
-    "        self.class_weights = dict(enumerate(self.class_weights))\n",
-    "\n",
-    "        self.one_hot_labels = self.one_hot.fit_transform(self.encoded_labels.reshape(-1, 1))\n",
-    "        \n",
     "        t2 = time.time()\n",
     "        \n",
-    "        self.history = self.model.fit(X, self.one_hot_labels, epochs=self.epochs, batch_size=self.batch_size, \\\n",
-    "                                      class_weight=self.class_weights, verbose=self.verbose)\n",
+    "        self.history = self.model.fit(X, y, epochs=self.epochs, batch_size=self.batch_size, \\\n",
+    "                                      class_weight=class_weights, verbose=self.verbose)\n",
     "        \n",
     "        print('Done training {} model                           total: {}mins'.format(self.name, \\\n",
     "                                                                          round((time.time()-t2)/60, 1)))\n",
@@ -1267,98 +1365,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2020-11-13T16:27:01.396612Z",
-     "iopub.status.busy": "2020-11-13T16:27:01.394844Z",
-     "iopub.status.idle": "2020-11-13T16:27:01.397400Z",
-     "shell.execute_reply": "2020-11-13T16:27:01.397910Z"
-    },
-    "papermill": {
-     "duration": 0.056416,
-     "end_time": "2020-11-13T16:27:01.398034",
-     "exception": false,
-     "start_time": "2020-11-13T16:27:01.341618",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "cnn_model = NLPModel(build_cnn_model)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 38,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2020-11-13T16:27:01.499804Z",
-     "iopub.status.busy": "2020-11-13T16:27:01.498811Z",
-     "iopub.status.idle": "2020-11-13T16:27:01.501884Z",
-     "shell.execute_reply": "2020-11-13T16:27:01.501383Z"
-    },
-    "papermill": {
-     "duration": 0.054475,
-     "end_time": "2020-11-13T16:27:01.501988",
-     "exception": false,
-     "start_time": "2020-11-13T16:27:01.447513",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "lstm_model = NLPModel(build_lstm_model)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 39,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2020-11-13T16:27:01.606915Z",
-     "iopub.status.busy": "2020-11-13T16:27:01.606052Z",
-     "iopub.status.idle": "2020-11-13T16:27:01.608525Z",
-     "shell.execute_reply": "2020-11-13T16:27:01.609025Z"
-    },
-    "papermill": {
-     "duration": 0.056055,
-     "end_time": "2020-11-13T16:27:01.609149",
-     "exception": false,
-     "start_time": "2020-11-13T16:27:01.553094",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "union = FeatureUnion([('cnn_model', cnn_model), ('lstm_model', lstm_model)])"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 40,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-13T16:27:01.714089Z",
-     "iopub.status.busy": "2020-11-13T16:27:01.713199Z",
-     "iopub.status.idle": "2020-11-13T16:27:01.715944Z",
-     "shell.execute_reply": "2020-11-13T16:27:01.715357Z"
+     "iopub.execute_input": "2020-11-14T07:17:59.547037Z",
+     "iopub.status.busy": "2020-11-14T07:17:59.546298Z",
+     "iopub.status.idle": "2020-11-14T07:17:59.550857Z",
+     "shell.execute_reply": "2020-11-14T07:17:59.550137Z"
     },
     "papermill": {
-     "duration": 0.056254,
-     "end_time": "2020-11-13T16:27:01.716041",
+     "duration": 0.067444,
+     "end_time": "2020-11-14T07:17:59.550978",
      "exception": false,
-     "start_time": "2020-11-13T16:27:01.659787",
+     "start_time": "2020-11-14T07:17:59.483534",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [],
    "source": [
-    "data_prep2 = Pipeline([('data_prep', data_prep_pipe), ('union', union)], verbose=1)"
+    "cnn_model = NLPModel(build_cnn_model, 'cnn_model', epochs=7) # instatiating cnn model object"
    ]
   },
   {
@@ -1366,39 +1392,23 @@
    "execution_count": 41,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-13T16:27:01.838627Z",
-     "iopub.status.busy": "2020-11-13T16:27:01.828361Z",
-     "iopub.status.idle": "2020-11-13T16:37:10.820364Z",
-     "shell.execute_reply": "2020-11-13T16:37:10.819858Z"
+     "iopub.execute_input": "2020-11-14T07:17:59.677591Z",
+     "iopub.status.busy": "2020-11-14T07:17:59.675693Z",
+     "iopub.status.idle": "2020-11-14T07:17:59.678314Z",
+     "shell.execute_reply": "2020-11-14T07:17:59.678876Z"
     },
     "papermill": {
-     "duration": 609.0548,
-     "end_time": "2020-11-13T16:37:10.820475",
+     "duration": 0.06795,
+     "end_time": "2020-11-14T07:17:59.679007",
      "exception": false,
-     "start_time": "2020-11-13T16:27:01.765675",
+     "start_time": "2020-11-14T07:17:59.611057",
      "status": "completed"
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[Pipeline] ........ (step 1 of 3) Processing get_tokens, total= 1.1min\n",
-      "[Pipeline] ... (step 2 of 3) Processing text_2_sequence, total=   6.0s\n",
-      "[Pipeline] ........... (step 3 of 3) Processing padding, total=   1.8s\n",
-      "[Pipeline] ......... (step 1 of 2) Processing data_prep, total= 1.2min\n",
-      "Done training Word2Vec for cnn_model                    total: 1.7mins\n",
-      "Done training cnn_model model                           total: 0.9mins\n",
-      "Done training Word2Vec for lstm_model                    total: 1.7mins\n",
-      "Done training lstm_model model                           total: 3.9mins\n",
-      "[Pipeline] ............. (step 2 of 2) Processing union, total= 8.9min\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "Xtt = data_prep2.fit_transform(sent_oversample_corpus, labels)"
+    "lstm_model = NLPModel(build_lstm_model, 'lstm_model', epochs=10) # instatiating cnn model object"
    ]
   },
   {
@@ -1406,93 +1416,137 @@
    "execution_count": 42,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-13T16:37:10.933411Z",
-     "iopub.status.busy": "2020-11-13T16:37:10.932456Z",
-     "iopub.status.idle": "2020-11-13T16:37:10.937893Z",
-     "shell.execute_reply": "2020-11-13T16:37:10.937393Z"
+     "iopub.execute_input": "2020-11-14T07:17:59.805720Z",
+     "iopub.status.busy": "2020-11-14T07:17:59.803848Z",
+     "iopub.status.idle": "2020-11-14T07:17:59.806542Z",
+     "shell.execute_reply": "2020-11-14T07:17:59.807043Z"
     },
     "papermill": {
-     "duration": 0.06415,
-     "end_time": "2020-11-13T16:37:10.937995",
+     "duration": 0.067755,
+     "end_time": "2020-11-14T07:17:59.807166",
      "exception": false,
-     "start_time": "2020-11-13T16:37:10.873845",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(159648, 40)"
-      ]
-     },
-     "execution_count": 42,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "Xtt.shape"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 43,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2020-11-13T16:37:11.047481Z",
-     "iopub.status.busy": "2020-11-13T16:37:11.046865Z",
-     "iopub.status.idle": "2020-11-13T16:37:11.051494Z",
-     "shell.execute_reply": "2020-11-13T16:37:11.050923Z"
-    },
-    "papermill": {
-     "duration": 0.060456,
-     "end_time": "2020-11-13T16:37:11.051623",
-     "exception": false,
-     "start_time": "2020-11-13T16:37:10.991167",
+     "start_time": "2020-11-14T07:17:59.739411",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [],
    "source": [
-    "ytt = union.transformer_list[0][1].one_hot_labels"
+    "union = FeatureUnion([('cnn_model', cnn_model), ('lstm_model', lstm_model)]) # union of cnn and lstm"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "papermill": {
+     "duration": 0.059576,
+     "end_time": "2020-11-14T07:17:59.926427",
+     "exception": false,
+     "start_time": "2020-11-14T07:17:59.866851",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-11-14T07:18:00.054567Z",
+     "iopub.status.busy": "2020-11-14T07:18:00.052942Z",
+     "iopub.status.idle": "2020-11-14T07:18:00.055290Z",
+     "shell.execute_reply": "2020-11-14T07:18:00.055868Z"
+    },
+    "papermill": {
+     "duration": 0.070481,
+     "end_time": "2020-11-14T07:18:00.056003",
+     "exception": false,
+     "start_time": "2020-11-14T07:17:59.985522",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# building a MLP model as our blender\n",
+    "def build_blender():\n",
+    "    model = Sequential()\n",
+    "\n",
+    "    model.add(Dense(30, activation='relu')) # this layer will find the best combination of CNN and LSTM\n",
+    "    model.add(Dense(20, activation='softmax')) \n",
+    "    \n",
+    "    model.compile(loss='categorical_crossentropy',optimizer=Adam(1e-2) ,metrics=['accuracy', multi_class_fbeta])\n",
+    "\n",
+    "    return model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "papermill": {
+     "duration": 0.060923,
+     "end_time": "2020-11-14T07:18:00.178161",
+     "exception": false,
+     "start_time": "2020-11-14T07:18:00.117238",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",
    "execution_count": 44,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-13T16:37:11.167108Z",
-     "iopub.status.busy": "2020-11-13T16:37:11.165887Z",
-     "iopub.status.idle": "2020-11-13T16:37:11.170011Z",
-     "shell.execute_reply": "2020-11-13T16:37:11.169498Z"
+     "iopub.execute_input": "2020-11-14T07:18:00.316440Z",
+     "iopub.status.busy": "2020-11-14T07:18:00.314286Z",
+     "iopub.status.idle": "2020-11-14T07:18:00.317229Z",
+     "shell.execute_reply": "2020-11-14T07:18:00.317802Z"
     },
     "papermill": {
-     "duration": 0.066397,
-     "end_time": "2020-11-13T16:37:11.170112",
+     "duration": 0.078272,
+     "end_time": "2020-11-14T07:18:00.317940",
      "exception": false,
-     "start_time": "2020-11-13T16:37:11.103715",
+     "start_time": "2020-11-14T07:18:00.239668",
      "status": "completed"
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(159648, 20)"
-      ]
-     },
-     "execution_count": 44,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "ytt.shape"
+    "# making the blender a scikit-learn classifier\n",
+    "class BlenderModel(BaseEstimator, ClassifierMixin):\n",
+    "    def __init__(self, build_fn, epochs=20, batch_size=128, verbose=1, validation_split=0):\n",
+    "        self.build_fn = build_fn\n",
+    "        self.epochs = epochs\n",
+    "        self.batch_size = batch_size\n",
+    "        self.verbose = verbose\n",
+    "        self.validate = validation_split\n",
+    "        \n",
+    "    def fit(self, X, y):\n",
+    "        if self.validate:\n",
+    "            self.model = KerasClassifier(build_fn=self.build_fn, epochs=self.epochs, \\\n",
+    "                                         batch_size=self.batch_size, validation_split=self.validate, \\\n",
+    "                                         verbose=self.verbose)\n",
+    "        else:\n",
+    "            self.model = KerasClassifier(build_fn=self.build_fn, epochs=self.epochs, \\\n",
+    "                                         batch_size=self.batch_size, verbose=self.verbose)\n",
+    "                    \n",
+    "        self.history = self.model.fit(X, y)\n",
+    "        \n",
+    "        return self\n",
+    "        \n",
+    "    def predict(self, X):\n",
+    "        self.ypred = self.model.predict(X)\n",
+    "        \n",
+    "        return self.ypred"
    ]
   },
   {
@@ -1500,30 +1554,23 @@
    "execution_count": 45,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-13T16:37:11.282320Z",
-     "iopub.status.busy": "2020-11-13T16:37:11.281446Z",
-     "iopub.status.idle": "2020-11-13T16:37:11.284461Z",
-     "shell.execute_reply": "2020-11-13T16:37:11.283981Z"
+     "iopub.execute_input": "2020-11-14T07:18:00.447078Z",
+     "iopub.status.busy": "2020-11-14T07:18:00.446204Z",
+     "iopub.status.idle": "2020-11-14T07:18:00.450492Z",
+     "shell.execute_reply": "2020-11-14T07:18:00.449886Z"
     },
     "papermill": {
-     "duration": 0.062298,
-     "end_time": "2020-11-13T16:37:11.284594",
+     "duration": 0.070736,
+     "end_time": "2020-11-14T07:18:00.450614",
      "exception": false,
-     "start_time": "2020-11-13T16:37:11.222296",
+     "start_time": "2020-11-14T07:18:00.379878",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [],
    "source": [
-    "def build_blender():\n",
-    "    model = Sequential()\n",
-    "\n",
-    "    model.add(Dense(20, activation='softmax')) # this layer will find the best combination of CNN and LSTM\n",
-    "    \n",
-    "    model.compile(loss='categorical_crossentropy',optimizer='adam',metrics=['accuracy', multi_class_fbeta])\n",
-    "\n",
-    "    return model"
+    "model = BlenderModel(build_blender, validation_split=0.25) # creating an instance of the blender"
    ]
   },
   {
@@ -1531,23 +1578,23 @@
    "execution_count": 46,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-13T16:37:11.404370Z",
-     "iopub.status.busy": "2020-11-13T16:37:11.403257Z",
-     "iopub.status.idle": "2020-11-13T16:37:11.419189Z",
-     "shell.execute_reply": "2020-11-13T16:37:11.418078Z"
+     "iopub.execute_input": "2020-11-14T07:18:00.588482Z",
+     "iopub.status.busy": "2020-11-14T07:18:00.586470Z",
+     "iopub.status.idle": "2020-11-14T07:18:00.589156Z",
+     "shell.execute_reply": "2020-11-14T07:18:00.589676Z"
     },
     "papermill": {
-     "duration": 0.081576,
-     "end_time": "2020-11-13T16:37:11.419299",
+     "duration": 0.069437,
+     "end_time": "2020-11-14T07:18:00.589802",
      "exception": false,
-     "start_time": "2020-11-13T16:37:11.337723",
+     "start_time": "2020-11-14T07:18:00.520365",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [],
    "source": [
-    "model = build_blender()"
+    "model_pipe = Pipeline([('union', union), ('blender', model)], verbose=1) # blender CNN and LSTM with MLP"
    ]
   },
   {
@@ -1555,16 +1602,16 @@
    "execution_count": 47,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-13T16:37:11.530875Z",
-     "iopub.status.busy": "2020-11-13T16:37:11.530155Z",
-     "iopub.status.idle": "2020-11-13T16:38:11.615449Z",
-     "shell.execute_reply": "2020-11-13T16:38:11.614864Z"
+     "iopub.execute_input": "2020-11-14T07:18:00.750690Z",
+     "iopub.status.busy": "2020-11-14T07:18:00.735371Z",
+     "iopub.status.idle": "2020-11-14T07:30:10.758113Z",
+     "shell.execute_reply": "2020-11-14T07:30:10.757516Z"
     },
     "papermill": {
-     "duration": 60.143382,
-     "end_time": "2020-11-13T16:38:11.615614",
+     "duration": 730.108153,
+     "end_time": "2020-11-14T07:30:10.758227",
      "exception": false,
-     "start_time": "2020-11-13T16:37:11.472232",
+     "start_time": "2020-11-14T07:18:00.650074",
      "status": "completed"
     },
     "tags": []
@@ -1574,62 +1621,67 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "Done training Word2Vec for cnn_model                    total: 1.9mins\n",
+      "Done training cnn_model model                           total: 1.0mins\n",
+      "Done training Word2Vec for lstm_model                    total: 1.8mins\n",
+      "Done training lstm_model model                           total: 5.8mins\n",
+      "[Pipeline] ............. (step 1 of 2) Processing union, total=11.1min\n",
       "Epoch 1/20\n",
-      "936/936 [==============================] - 3s 3ms/step - loss: 1.7579 - accuracy: 0.7759 - multi_class_fbeta: 0.7561 - val_loss: 1.1761 - val_accuracy: 0.8719 - val_multi_class_fbeta: 0.8747\n",
+      "936/936 [==============================] - 3s 3ms/step - loss: 0.3034 - accuracy: 0.9218 - multi_class_fbeta: 0.9215 - val_loss: 0.3236 - val_accuracy: 0.9041 - val_multi_class_fbeta: 0.9083\n",
       "Epoch 2/20\n",
-      "936/936 [==============================] - 3s 3ms/step - loss: 0.6582 - accuracy: 0.9103 - multi_class_fbeta: 0.9114 - val_loss: 0.6108 - val_accuracy: 0.8834 - val_multi_class_fbeta: 0.8868\n",
+      "936/936 [==============================] - 3s 3ms/step - loss: 0.2387 - accuracy: 0.9281 - multi_class_fbeta: 0.9286 - val_loss: 0.3187 - val_accuracy: 0.9037 - val_multi_class_fbeta: 0.9079\n",
       "Epoch 3/20\n",
-      "936/936 [==============================] - 3s 4ms/step - loss: 0.4133 - accuracy: 0.9116 - multi_class_fbeta: 0.9131 - val_loss: 0.4709 - val_accuracy: 0.8846 - val_multi_class_fbeta: 0.8881\n",
+      "936/936 [==============================] - 4s 4ms/step - loss: 0.2302 - accuracy: 0.9292 - multi_class_fbeta: 0.9293 - val_loss: 0.3097 - val_accuracy: 0.9032 - val_multi_class_fbeta: 0.9080\n",
       "Epoch 4/20\n",
-      "936/936 [==============================] - 3s 3ms/step - loss: 0.3435 - accuracy: 0.9121 - multi_class_fbeta: 0.9136 - val_loss: 0.4225 - val_accuracy: 0.8850 - val_multi_class_fbeta: 0.8885\n",
+      "936/936 [==============================] - 4s 4ms/step - loss: 0.2224 - accuracy: 0.9292 - multi_class_fbeta: 0.9295 - val_loss: 0.2936 - val_accuracy: 0.9048 - val_multi_class_fbeta: 0.9082\n",
       "Epoch 5/20\n",
-      "936/936 [==============================] - 4s 4ms/step - loss: 0.3157 - accuracy: 0.9127 - multi_class_fbeta: 0.9140 - val_loss: 0.4018 - val_accuracy: 0.8851 - val_multi_class_fbeta: 0.8887\n",
+      "936/936 [==============================] - 3s 4ms/step - loss: 0.2167 - accuracy: 0.9295 - multi_class_fbeta: 0.9296 - val_loss: 0.2885 - val_accuracy: 0.9039 - val_multi_class_fbeta: 0.9087\n",
       "Epoch 6/20\n",
-      "936/936 [==============================] - 3s 3ms/step - loss: 0.3025 - accuracy: 0.9132 - multi_class_fbeta: 0.9143 - val_loss: 0.3915 - val_accuracy: 0.8851 - val_multi_class_fbeta: 0.8889\n",
+      "936/936 [==============================] - 3s 4ms/step - loss: 0.2128 - accuracy: 0.9300 - multi_class_fbeta: 0.9302 - val_loss: 0.2908 - val_accuracy: 0.9042 - val_multi_class_fbeta: 0.9092\n",
       "Epoch 7/20\n",
-      "936/936 [==============================] - 3s 3ms/step - loss: 0.2953 - accuracy: 0.9136 - multi_class_fbeta: 0.9147 - val_loss: 0.3864 - val_accuracy: 0.8852 - val_multi_class_fbeta: 0.8891\n",
+      "936/936 [==============================] - 3s 3ms/step - loss: 0.2103 - accuracy: 0.9303 - multi_class_fbeta: 0.9303 - val_loss: 0.2905 - val_accuracy: 0.9033 - val_multi_class_fbeta: 0.9076\n",
       "Epoch 8/20\n",
-      "936/936 [==============================] - 3s 3ms/step - loss: 0.2911 - accuracy: 0.9138 - multi_class_fbeta: 0.9149 - val_loss: 0.3831 - val_accuracy: 0.8854 - val_multi_class_fbeta: 0.8892\n",
+      "936/936 [==============================] - 3s 3ms/step - loss: 0.2088 - accuracy: 0.9304 - multi_class_fbeta: 0.9305 - val_loss: 0.2876 - val_accuracy: 0.9009 - val_multi_class_fbeta: 0.9053\n",
       "Epoch 9/20\n",
-      "936/936 [==============================] - 3s 3ms/step - loss: 0.2884 - accuracy: 0.9141 - multi_class_fbeta: 0.9152 - val_loss: 0.3814 - val_accuracy: 0.8857 - val_multi_class_fbeta: 0.8895\n",
+      "936/936 [==============================] - 3s 3ms/step - loss: 0.2074 - accuracy: 0.9305 - multi_class_fbeta: 0.9306 - val_loss: 0.2870 - val_accuracy: 0.9028 - val_multi_class_fbeta: 0.9077\n",
       "Epoch 10/20\n",
-      "936/936 [==============================] - 3s 3ms/step - loss: 0.2865 - accuracy: 0.9143 - multi_class_fbeta: 0.9154 - val_loss: 0.3803 - val_accuracy: 0.8856 - val_multi_class_fbeta: 0.8895\n",
+      "936/936 [==============================] - 3s 4ms/step - loss: 0.2063 - accuracy: 0.9307 - multi_class_fbeta: 0.9308 - val_loss: 0.2869 - val_accuracy: 0.9014 - val_multi_class_fbeta: 0.9059\n",
       "Epoch 11/20\n",
-      "936/936 [==============================] - 3s 3ms/step - loss: 0.2852 - accuracy: 0.9143 - multi_class_fbeta: 0.9155 - val_loss: 0.3795 - val_accuracy: 0.8856 - val_multi_class_fbeta: 0.8895\n",
+      "936/936 [==============================] - 3s 3ms/step - loss: 0.2059 - accuracy: 0.9304 - multi_class_fbeta: 0.9305 - val_loss: 0.2870 - val_accuracy: 0.9023 - val_multi_class_fbeta: 0.9067\n",
       "Epoch 12/20\n",
-      "936/936 [==============================] - 3s 3ms/step - loss: 0.2842 - accuracy: 0.9146 - multi_class_fbeta: 0.9156 - val_loss: 0.3788 - val_accuracy: 0.8858 - val_multi_class_fbeta: 0.8898\n",
+      "936/936 [==============================] - 3s 3ms/step - loss: 0.2045 - accuracy: 0.9312 - multi_class_fbeta: 0.9312 - val_loss: 0.2911 - val_accuracy: 0.8995 - val_multi_class_fbeta: 0.9040\n",
       "Epoch 13/20\n",
-      "936/936 [==============================] - 3s 3ms/step - loss: 0.2834 - accuracy: 0.9147 - multi_class_fbeta: 0.9156 - val_loss: 0.3781 - val_accuracy: 0.8858 - val_multi_class_fbeta: 0.8899\n",
+      "936/936 [==============================] - 3s 4ms/step - loss: 0.2043 - accuracy: 0.9306 - multi_class_fbeta: 0.9306 - val_loss: 0.2908 - val_accuracy: 0.9013 - val_multi_class_fbeta: 0.9058\n",
       "Epoch 14/20\n",
-      "936/936 [==============================] - 3s 3ms/step - loss: 0.2827 - accuracy: 0.9147 - multi_class_fbeta: 0.9157 - val_loss: 0.3777 - val_accuracy: 0.8855 - val_multi_class_fbeta: 0.8896\n",
+      "936/936 [==============================] - 3s 4ms/step - loss: 0.2035 - accuracy: 0.9305 - multi_class_fbeta: 0.9306 - val_loss: 0.2890 - val_accuracy: 0.9023 - val_multi_class_fbeta: 0.9070\n",
       "Epoch 15/20\n",
-      "936/936 [==============================] - 3s 3ms/step - loss: 0.2822 - accuracy: 0.9148 - multi_class_fbeta: 0.9159 - val_loss: 0.3778 - val_accuracy: 0.8856 - val_multi_class_fbeta: 0.8896\n",
+      "936/936 [==============================] - 3s 3ms/step - loss: 0.2028 - accuracy: 0.9308 - multi_class_fbeta: 0.9309 - val_loss: 0.2868 - val_accuracy: 0.9017 - val_multi_class_fbeta: 0.9069\n",
       "Epoch 16/20\n",
-      "936/936 [==============================] - 4s 4ms/step - loss: 0.2818 - accuracy: 0.9150 - multi_class_fbeta: 0.9160 - val_loss: 0.3777 - val_accuracy: 0.8856 - val_multi_class_fbeta: 0.8897\n",
+      "936/936 [==============================] - 3s 3ms/step - loss: 0.2027 - accuracy: 0.9312 - multi_class_fbeta: 0.9312 - val_loss: 0.2831 - val_accuracy: 0.9041 - val_multi_class_fbeta: 0.9082\n",
       "Epoch 17/20\n",
-      "936/936 [==============================] - 3s 3ms/step - loss: 0.2814 - accuracy: 0.9149 - multi_class_fbeta: 0.9158 - val_loss: 0.3774 - val_accuracy: 0.8857 - val_multi_class_fbeta: 0.8897\n",
+      "936/936 [==============================] - 3s 4ms/step - loss: 0.2028 - accuracy: 0.9310 - multi_class_fbeta: 0.9311 - val_loss: 0.2880 - val_accuracy: 0.9027 - val_multi_class_fbeta: 0.9075\n",
       "Epoch 18/20\n",
-      "936/936 [==============================] - 3s 3ms/step - loss: 0.2811 - accuracy: 0.9151 - multi_class_fbeta: 0.9158 - val_loss: 0.3772 - val_accuracy: 0.8858 - val_multi_class_fbeta: 0.8898\n",
+      "936/936 [==============================] - 3s 3ms/step - loss: 0.2019 - accuracy: 0.9309 - multi_class_fbeta: 0.9309 - val_loss: 0.2842 - val_accuracy: 0.9032 - val_multi_class_fbeta: 0.9081\n",
       "Epoch 19/20\n",
-      "936/936 [==============================] - 3s 3ms/step - loss: 0.2808 - accuracy: 0.9152 - multi_class_fbeta: 0.9160 - val_loss: 0.3772 - val_accuracy: 0.8855 - val_multi_class_fbeta: 0.8896\n",
+      "936/936 [==============================] - 3s 3ms/step - loss: 0.2019 - accuracy: 0.9314 - multi_class_fbeta: 0.9314 - val_loss: 0.2859 - val_accuracy: 0.9032 - val_multi_class_fbeta: 0.9072\n",
       "Epoch 20/20\n",
-      "936/936 [==============================] - 3s 3ms/step - loss: 0.2805 - accuracy: 0.9152 - multi_class_fbeta: 0.9163 - val_loss: 0.3770 - val_accuracy: 0.8858 - val_multi_class_fbeta: 0.8899\n"
+      "936/936 [==============================] - 3s 4ms/step - loss: 0.2016 - accuracy: 0.9315 - multi_class_fbeta: 0.9315 - val_loss: 0.2931 - val_accuracy: 0.9019 - val_multi_class_fbeta: 0.9061\n",
+      "[Pipeline] ........... (step 2 of 2) Processing blender, total= 1.1min\n"
      ]
     }
    ],
    "source": [
-    "history = model.fit(Xtt, ytt, epochs=20, batch_size=128, \\\n",
-    "                    validation_split=0.25, verbose=1)"
+    "model_pipe.fit(X_prep, encoded_labels);"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.373573,
-     "end_time": "2020-11-13T16:38:12.363166",
+     "duration": 0.450594,
+     "end_time": "2020-11-14T07:30:11.649484",
      "exception": false,
-     "start_time": "2020-11-13T16:38:11.989593",
+     "start_time": "2020-11-14T07:30:11.198890",
      "status": "completed"
     },
     "tags": []
@@ -1643,16 +1695,16 @@
    "execution_count": 48,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-13T16:38:13.129039Z",
-     "iopub.status.busy": "2020-11-13T16:38:13.127174Z",
-     "iopub.status.idle": "2020-11-13T16:38:13.129800Z",
-     "shell.execute_reply": "2020-11-13T16:38:13.130262Z"
+     "iopub.execute_input": "2020-11-14T07:30:12.553247Z",
+     "iopub.status.busy": "2020-11-14T07:30:12.551181Z",
+     "iopub.status.idle": "2020-11-14T07:30:12.553994Z",
+     "shell.execute_reply": "2020-11-14T07:30:12.554549Z"
     },
     "papermill": {
-     "duration": 0.390533,
-     "end_time": "2020-11-13T16:38:13.130378",
+     "duration": 0.459357,
+     "end_time": "2020-11-14T07:30:12.554684",
      "exception": false,
-     "start_time": "2020-11-13T16:38:12.739845",
+     "start_time": "2020-11-14T07:30:12.095327",
      "status": "completed"
     },
     "tags": []
@@ -1670,12 +1722,11 @@
     "    val_loss = history.history['val_loss']\n",
     "    epochs = range(1, len(acc)+1)\n",
     "\n",
-    "    metrics = {'loss': (loss, val_loss), 'accuracy': (acc, val_acc), 'fbeta': (fbeta, val_fbeta)}\n",
+    "    metrics = {'loss': (loss, val_loss)}\n",
     "    \n",
     "    plt.figure(figsize=(18, 5))\n",
     "    \n",
-    "    for i, metric in zip(range(1, 4), list(metrics.keys())):\n",
-    "        plt.subplot(1, 3, i)\n",
+    "    for i, metric in zip(range(1, len(list(metrics.keys()))+1), list(metrics.keys())):\n",
     "        plt.plot(epochs, metrics[metric][0], 'b', label='Training ' + metric)\n",
     "        plt.plot(epochs, metrics[metric][1], 'r', label='Validation ' + metric)\n",
     "        plt.title('Training and validation ' + metric)\n",
@@ -1687,16 +1738,16 @@
    "execution_count": 49,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-13T16:38:13.880489Z",
-     "iopub.status.busy": "2020-11-13T16:38:13.879792Z",
-     "iopub.status.idle": "2020-11-13T16:38:14.455425Z",
-     "shell.execute_reply": "2020-11-13T16:38:14.456061Z"
+     "iopub.execute_input": "2020-11-14T07:30:13.447958Z",
+     "iopub.status.busy": "2020-11-14T07:30:13.447113Z",
+     "iopub.status.idle": "2020-11-14T07:30:13.717861Z",
+     "shell.execute_reply": "2020-11-14T07:30:13.717173Z"
     },
     "papermill": {
-     "duration": 0.955853,
-     "end_time": "2020-11-13T16:38:14.456209",
+     "duration": 0.725143,
+     "end_time": "2020-11-14T07:30:13.717989",
      "exception": false,
-     "start_time": "2020-11-13T16:38:13.500356",
+     "start_time": "2020-11-14T07:30:12.992846",
      "status": "completed"
     },
     "tags": []
@@ -1704,9 +1755,9 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABBEAAAFACAYAAADqEeSeAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAgAElEQVR4nOzdeXgT1foH8O8kaZt0pWksFdqyLwUEZBFEBSqlFlnER0W8gAuigAurKDsigl6lCCgICBZxuZersqkXflIEEVHggmAFxBbZQUrXpEvaJjO/P4akSZt0TZukfj/PkyeZ/Z20PZ3zzjlnBEmSJBARERERERERVULh7gCIiIiIiIiIyDswiUBEREREREREVcIkAhERERERERFVCZMIRERERERERFQlTCIQERERERERUZUwiUBEREREREREVcIkggfat28fBEHA5cuXq7WdIAj45JNP6iiq+lMf53H+/HkIgoADBw5U67j9+/fHuHHjan38jRs3QqVS1Xo/VeGqmIm8BctQlqFE5J1YfrP8diWTyYSxY8ciLCwMgiBg3759vC52ESYRakEQhApfzZs3r9F++/Tpg2vXrqFJkybV2u7atWt4+OGHa3RMqpvv7/Lly9ZCy9ajjz6KK1euuPRYRN6GZWjDwjKU6O+D5XfD0lDL7y+//BKfffYZvvrqK1y7dg19+vRx2b5bt26NV1991WX78zZM49fCtWvXrJ8PHz6MBx54AIcPH0ZUVBQAQKlU2q1fXFwMX1/fSvfr6+uLiIiIasdTk22oVH1+fxqNBhqNpt6OR+SJWIY2LCxD61dV/x6I6gLL74aloZbfqampaNq0qUuTByRjS4RaiIiIsL60Wi0A4JZbbrHOCw8Px8qVK/GPf/wDISEhGDVqFABgzpw5iImJgb+/P6KiojBhwgTk5uZa91u2KZdlevfu3ejbty/8/f3RoUMH/N///Z9dPGWbIgmCgNWrV2PMmDEICgpCVFQU3nrrLbttMjMz8cgjjyAgIACNGzfGvHnz8MQTTyAuLq7Cc6/sHCxNlX788Ud069YN/v7+6NmzJ44ePWq3n71796Jz585Qq9Xo3Lkz9u7dW+FxU1NTIQgCDh48aDf/0KFDEAQBv//+OwBgxYoV6Nq1KwIDAxEREYGRI0fa/cNzpOz3d+HCBSQkJECj0SA6OhrvvvtuuW0+++wz9OrVCyEhIdDpdBg8eDD++OMP63LLP9PY2Fi7zLyjplz//e9/0b17d/j5+SE8PBzPPfcc8vPzrcuffPJJxMXFYd26dWjWrBmCg4PxwAMP4MaNGxWeV1klJSWYOXMmmjZtCl9fX3To0AGfffaZ3Trr169HTEwM1Go1wsLC0LdvX+vvo16vx1NPPYWIiAj4+fkhKioK06ZNq1YMRADLUJah3lGGVhYjAKSnp+Opp55C48aNoVar0a5dO3z44YfW5WfPnsUjjzwCrVYLf39/dO7cGV9//bXTcyl7B8/yO/zNN9/g7rvvhlqtxrp165CdnY3Ro0cjOjoaGo0G7dq1Q2JiIiRJstvf5s2b0b17d2uZPmjQIGRnZyMpKQmNGjVCQUGB3foLFy5EixYtyu2HyILlN8tvTy+/+/fvj3nz5uHPP/8s1zpGFEXMnDkTOp0OwcHBGDduHAoLC+22f/fdd9G+fXuo1Wq0adMGixcvhslksu777NmzWLhwobX1zfnz5yFJEp555hm0atUKGo0GLVu2xOzZs1FUVFTh9++NmESoYwsXLsSdd96JY8eOYfHixQDkDNy6detw6tQpbNy4Efv27cOkSZMq3ddLL72E2bNn48SJE+jRowceffRR5OTkVHr8vn374vjx45gxYwZeeeUVu0LqqaeewokTJ/D111/ju+++w+XLl7Ft27ZKY6nKOYiiiFmzZmHFihU4duwYQkNDMWLECOsf4NWrVzFkyBB0794dx44dQ2JiIiZPnlzhcdu0aYPevXvjo48+spv/8ccf44477kD79u2t85YuXYqUlBRs3boVFy9exMiRIys9LwtJkvDggw8iMzMT+/btw44dO7Bjxw4cO3bMbr2ioiLMmzcPx44dw+7du6FUKjF48GAUFxcDgHX9L7/8EteuXcORI0ccHu/XX3/FsGHDrD+rjz76CF9//TUmTJhgt96RI0ewd+9efPPNN9i1axeOHz+Ol156qcrnBQCzZ8/GBx98gOXLl+O3337D6NGjMXr0aOzZswcAcPToUUyYMAGzZs3CmTNnsG/fPjz++OPW7efOnYtjx45h+/btSE1NxebNmxETE1OtGIiqimUoy1DAvWVoZTEWFhaiX79+OHHiBD799FOcOnUK7777Lvz9/QEAf/31F/r06YPs7Gzs2LEDKSkpWLRoERSK6l+CTZ8+HS+//DJOnz6N4cOHo6ioCLfddhu2bduGU6dOYd68eViwYAE2btxo3SYpKQmjR4/G8OHDcezYMezduxcJCQkwm80YOXIkBEHA559/bl1fFEUkJSVh3LhxEASh2jESWbD8ZvkNuK/83rJlC6ZPn47mzZuXO/4XX3yBzMxM/PDDD/j000+xY8cOvPLKK9blr776KpYuXYo33ngDp0+fxooVK7B27VosXLjQuu/mzZtj+vTpuHbtGq5du4aoqChIkoTGjRvjs88+w+nTp7F8+XIkJSVhyZIlVf7+vYZELvHDDz9IAKRz585Z5wGQxo4dW+m2W7ZskXx9fSWz2SxJkiTt3btXAiBdunTJbvrLL7+0bnPt2jUJgLRr1y6743388cd20y+++KLdsdq1ayfNnDlTkiRJ+uOPPyQAUnJysnV5cXGxFBkZKQ0YMKAaZ1/+HJKSkiQA0tGjR63r/PTTTxIA6ffff5ckSZLmzJkjRUdHSyUlJdZ1vvrqq3LnUdb7778vNWrUSDIajdaYdTqd9N577znd5tixYxIA6fLly5IkSdK5c+ckANIPP/xgXcf2uLt375YASGfOnLEuT09Pl9RqtfT00087PU5mZqYEQDpw4IAkSZJ06dIlCYC0d+9eu/WSkpIkpVJpnR49erTUs2dPu3W2bdsmCYIgnT9/XpIkSXriiScknU5nPW9JkqQ33nhDioiIcBqPJElSv379rDHn5+dLvr6+0qpVq+zWGT58uBQbGytJkvyzDA4OlnJzcx3ub9iwYdITTzxR4TGJqotlKMtQSfLMMrSyGNevXy/5+flZf9/Kmjt3rtS4cWMpLy/P4fKy5yJJ5c/b8ju8adOmSuObNGmSFBcXZ52OioqSnn/+eafrv/jii9Jdd91lnd61a5ekUqmkq1evVnosIkli+c3yW+aJ5feCBQukVq1a2c3r16+f1KxZM8lkMlnnrV27VvL19ZXy8vKk/Px8SaPRSDt37rTb7qOPPpJCQkKs061atZIWLFhQ4fElSZKWLVsmtW7dutL1vA1bItSxO+64o9y8LVu2oG/fvmjSpAkCAwMxatQoFBcX46+//qpwX127drV+joiIgFKpxPXr16u8DQA0bdrUus2pU6cAAL1797Yu9/HxQY8ePSo+qSqegyAI6NKli92xAdgd/4477rBr0nT33XdXeuxHH30UhYWF2LFjBwC5CZRer7fLsu7btw/33XcfoqKiEBQUZN3vhQsXKt2/JTadToe2bdta591yyy1o166d3XrHjx/Hgw8+iBYtWiAoKAjR0dHVOo7FyZMn0bdvX7t5/fr1gyRJ1p8TAMTExMDPz886bfvzrIq0tDQUFxc7PNbJkycBAAMHDkTLli3RokULjBw5EuvWrUNGRoZ13eeeew5ffPEFOnXqhMmTJ2Pnzp0QRbFa50tUVSxDWYZWRV2WoZXFePToUXTo0AGRkZEOtz969Cj69OmDgICAap2TI2X/HkRRxJtvvomuXbtCp9MhMDAQa9asscaWnp6OS5cuIT4+3uk+x48fjx9//NH6PX3wwQcYPHgwbr311lrHS39vLL9ZfldFfV0D27rjjjvsxu246667UFxcjLNnz+LkyZMoLCzEQw89hMDAQOtr/PjxyM3NrbQL3AcffIBevXqhcePGCAwMxKxZs6r9nXgDJhHqWNmLhkOHDuGRRx5B3759sXXrVhw7dgxr1qwBAGvzH2ccDUhTWeWt7DaCIJTbprrNFat6DgqFwu4P1HIcy/ElSSp37KrEEhoaiqFDh2LTpk0AgE2bNmHw4MEICwsDAFy8eBH3338/mjdvjn//+9/43//+Zy1sK/uOLRzFVlZBQQHi4+MhCAI+/PBDHD58GEeOHIEgCFU+ji1nx7Od7+jnKdWgz2rZY9meb2BgIP73v/9h69ataNu2LdasWYPWrVtb+/Ldd999uHjxIubMmQOj0YjRo0fj3nvvhdlsrnYcRJVhGcoytKrqogytaoyVnWtFyx11aygpKXG4btm/h8TERLzxxht48cUXsXv3bhw/fhzjxo0r9/1VdPyOHTvi7rvvxvr165Geno4dO3bg2Wefreh0iKqE5TfL76qqz2tgR2z3Y/kZff755zh+/Lj1lZKSgtTUVOsYII58/vnneP755/Hoo4/iv//9L3755RfMnz/faZnuzZhEqGcHDhyATqfD66+/jl69eqFt27bVfhauq3To0AEA8NNPP1nnmUymcgO/lOWqc+jYsSMOHTpkV/m0fWZtRR5//HHs2rULZ86cwTfffIMnnnjCuuzIkSMoLCzE8uXLcdddd6Fdu3bVzlR27NgRN27cQGpqqnVeRkaG3YAxp0+fxo0bN7B48WLExsYiJiYG2dnZdgWRpcCrrILdsWNHfP/993bzvv/+ewiCYP05uULr1q3h5+dX7lj79+9Hx44drdNKpRJ9+/bFa6+9hqNHj+LWW2+1G3xRq9Xisccew9q1a/HNN9/g+++/t8sWE9UVlqGlWIbaH68uytCqxNi9e3ecPHnS6c+we/fu+PHHH+0GCbMVHh4Os9ls9x2X7XvszP79+5GQkICnn34at99+O1q3bm33nYeHhyMyMrLcIHRljR8/Hps2bcK6desQERGBhISEKh2fqDpYfpdi+W1/vPq4BrZ15MgRu7h++ukn+Pr6olWrVujYsSPUajX+/PNPtG7dutzLkhzy9fUtd2779+/H7bffjmnTpqF79+5o06YNzp8/Xyfn4G5MItSzdu3a4caNG9iwYQP+/PNPbNq0CatXr3ZLLG3atMHQoUPx/PPPWyuB48ePh16vrzAD6apzmDhxIm7cuIFnn30Wp0+fxp49ezBnzpwqbTto0CBotVqMHDkSQUFBuP/+++3OSxAEJCYm4ty5c9i2bRtee+21asU2YMAAdOnSBaNHj8bhw4dx/PhxjBo1yq7ZWbNmzeDn54d3330XZ8+exZ49ezB58mS7787SvPTbb7/FX3/9hezsbIfHmzFjBo4dO4Zp06bh999/x65du/Diiy9i1KhR1uZhruDv749JkyZh3rx5+Pzzz5GamoolS5Zg+/btmD17NgBg+/bteOedd3D06FFcvHgR27Ztw6VLl6wF+Zw5c7BlyxacOXMGqamp+PTTTxEYGOjSOImcYRlaimVoqboqQ6sS42OPPYZmzZph2LBhSE5Oxrlz57Bnzx5s3rwZgNwFTBRFPPDAA/jxxx9x7tw5fP3119i5cycAuVltUFAQZs6cidTUVOzatavK33e7du2wb98+7N27F3/88Qfmzp2LQ4cO2a2zYMECrF27FosWLcLp06dx8uRJvPfee3bd1CzPh1+0aBGefvrpGg36SFQZlt+lWH6Xqq9rYFuZmZl4/vnncfr0aXzzzTeYN28ennnmGQQEBCAwMBCzZ8/G7Nmz8d577+HMmTM4efIk/v3vf9sNvtiiRQv8+OOPuHjxIjIyMiCKItq1a4eUlBRs374dZ8+exYoVK7Bly5Y6OQd343+JejZkyBDMmTMHs2fPxm233YZ///vfePvtt90WT1JSEjp16oRBgwahf//+aNq0KQYOHAi1Wu10G1edQ9OmTfHVV1/h8OHD6Nq1KyZPnoxly5ZVaVuVSoV//OMfOH78OEaOHAkfHx/rss6dO+Pdd9/F2rVr0aFDByxduhTLly+vVmyCIGDbtm0ICQlB3759MWTIENx///3o1q2bdR2dTodPPvkEu3fvRseOHfHSSy9h6dKldhdfCoUCq1atwn/+8x9ERUXh9ttvd3i8zp07Y8eOHfj+++/RpUsXjBkzBoMHD7Y2kXOlxYsX45lnnsGUKVPQsWNHfPLJJ/jkk08wYMAAAHJTua+++goJCQlo27YtXn75ZcydOxdjx44FAKjVasyfPx/du3dHjx498Ouvv2Lnzp0ICQlxeaxEZbEMLcUytFRdlaFVidHf3x/ff/89OnXqhJEjRyImJgbPP/+89XFht956Kw4cOGC92O/YsSPmzJljvWOn1Wrxr3/9Cz///DM6d+6MRYsWlXsUnTPz5s1Dv3798MADD+DOO+9EdnZ2uVHix40bh40bN+KLL75A165d0bdvX+zcudOuQqBWqzFmzBiYTCY8/fTTtfrOiJxh+V2K5Xep+rwGtnj44Yet40WMHDkS999/v125O2/ePLzzzjtYv349unTpgrvvvhvvvPOO3WMiFy5ciNzcXLRr1w633HILLl68iPHjx2PMmDF46qmncPvtt+PQoUN49dVX6+w83EmQXNWZhBoEs9mM9u3bY9iwYUhMTHR3OEREXoVlKHmrESNGoLCwEF999ZW7QyFyC5bfRFWnqnwVasj279+P9PR03H777TAYDHjnnXdw/vx5PPnkk+4OjYjI47EMJW+XnZ2NH374AVu3bsXu3bvdHQ5RvWH5TVRzTCL8zZnNZrz++utIS0uDj48POnXqhL179+K2225zd2hERB6PZSh5u9tvvx2ZmZl4+eWX0b9/f3eHQ1RvWH4T1Ry7MxARERERERFRlXBgRSIiIiIiIiKqEiYRiIiIiIiIiKhKOCYCEZEHOX78OJKSkiCKIgYMGIDhw4fbLc/Ly8P777+P69evw8fHBxMnTkR0dDQyMjKwatUq5OTkQBAExMXF2T07moiIiIjIFdyaRLh69ao7D2+l0+mQkZHh7jAAeFYsgGfFw1ic86R4GkIsTZo0qYNoKieKIjZs2IC5c+ciLCwMs2bNQo8ePRAZGWldZ+vWrWjevDlmzJiBK1euYMOGDZg/fz6USiXGjBmDli1borCwEDNnzkTnzp3ttnXGE8piT/q9ATwrHsbinCfFw1icq0k87iqH3cUTymHAs353GItznhQPY3HOk+Jx9TVxpUmE1atX49ixYwgJCXH4zNSCggKsXLkSmZmZMJvNGDp0KGJjY6sdIBHR311aWhoiIiLQuHFjAECfPn1w5MgRu0TA5cuX8eCDDwIAmjZtihs3biAnJwehoaEIDQ0FAGg0GjRt2hRZWVlVSiIQEREREVVVpUmE/v37IyEhAatWrXK4fNeuXYiMjMTMmTOh1+sxefJk3HPPPVCp2FOCiKg6srKyEBYWZp0OCwtDamqq3TrNmjXDoUOH0L59e6SlpeHGjRvIyspCo0aNrOukp6fj3LlzaN26db3FTkTUULBbGRFRxSqt6Xfo0AHp6elOlwuCAKPRCEmSYDQaERgYCIWC4zUSEVWXoyfuCoJgNz18+HBs3LgRM2bMQHR0NFq0aGFX5hqNRiQmJuLJJ5+Ev7+/w+MkJycjOTkZAPDmm29Cp9O58CxqRqVSeUQcFp4UD2NxzpPiYSzOeVo8FXFXtzIiIm9S6+YCCQkJeOuttzB+/HgUFhZi6tSpTpMInnjhCnjWPzdPigXwrHi8IRZJkpCVlQWTyVSv8aSnpzusgLqDN8WiUqmg1WrLVdTdJSwsDJmZmdbpzMxMaxcFC39/fzz33HMA5N+3F154AeHh4QAAk8mExMRE3HPPPejVq5fT48TFxSEuLs467Qn99Typ3yDgWfEwFuc8KR7G4pw3jYnAbmVERJWrdRLhxIkTaNasGebPn4/r169j0aJFaN++vcM7YJ544Qp41j9bT4oF8Kx4vCGWwsJC+Pj41Ht3HpVKVe+JC2e8KZaSkhJcvnwZGo3Gbr67Ll5btWqFa9euIT09HVqtFgcPHsSkSZPs1snPz4efnx9UKhX27NmDmJgY+Pv7Q5IkrFmzBk2bNsWQIUPcEj8RkbdjtzIiosrVuqazd+9eDB8+HIIgICIiAuHh4bh69SoLTfpbEkWR44F4EZVKhaKiIneHYaVUKjF27FgsXrwYoigiNjYWUVFR+PbbbwEA8fHxuHLlCt577z0oFApERkZiwoQJAIAzZ85g//79iI6OxowZMwAAjz32GLp16+a28yEi8jZ/525lgHe0+nQHT4oF8Kx4GItznhSPq2OpdW1Hp9MhJSUFMTExyMnJwdWrV61Na4n+bjylWTxVnaf9zLp161au4h8fH2/93LZtW6xcubLcdu3bt8d//vOfOo+PiKgh+zt3KwO8o9WnO3hSLIBnxcNYnPOkeOr9EY/Lly/HqVOnYDAYMGHCBIwYMcLaPDg+Ph4PPfQQVq9ejenTpwMARo0aheDg4GoHSES1l5WVhUcffRQAcOPGDSiVSmi1WgDAN998A19fX6fbnjhxAl988QUWLVpU4TGGDRuGHTt21DrWgwcPYs2aNdi0aVOt90VEROQK7FZGRFS5SpMIU6ZMqXC5VqvF3LlzXRYQEdWcVqvF7t27AQCJiYkICAiwNncH5DskzrpbdOnSBV26dKn0GK5IIBAREXkidisjIqqc13Te1usFfP21Br16FaFVK7O7wyHyGlOmTEGjRo3w22+/4bbbbsOwYcOwYMECGI1GqNVqLFu2DK1bt7ZrGZCYmIgrV67g4sWLuHLlCsaNG4enn34aANCmTRukpqbi4MGDWLZsGUJDQ3HmzBl07twZ7777LgBgz549WLhwIbRaLW677TZcuHChwhYH2dnZmD59Oi5evAi1Wo233noLHTp0wE8//YT58+cDkLsdbNmyBfn5+Zg4cSIMBgPMZjPeeOONCpuMEhF5IkkCzGZAFAGFQn4Jgvyqzf5KSgC9HsjOFmAyCTCZUO7dbAYkSYDZbIlBgCjCOm2/rHS5KMrHEUXLMQW7eZJk+xKs8wcOFHDzYQdegd3KiMiTmc1AUZEAo1F+Ly4WUFQkOJ1XVASEhCiQkOC6GLwmiWAwCJgxoxGWLs1Bq1YF7g6HyKv8+eef2Lx5M5RKJQwGA7Zs2QKVSoX9+/fjn//8Jz744INy26SlpeHzzz9Hfn4+7rnnHjz++OPw8fGxW+e3337Dd999h4iICDzwwAM4cuQIunXrhldeeQVbtmxBdHS0td9oRRITE9GpUyd8+OGHOHDgACZPnozdu3djzZo1WLJkCXr27GltPvrJJ5+gX79+mDx5MsxmMwoLC132PRFR3ZMkoLgYMBoFFBbKL8vnsvOMRuFmpdZ+e0sF1d9fgfz8gDKV19rFZzYLKC6WK9wlJUBxsVzxlt8dzQNKSgQAKhQW6lBSUjrPUqm3bGdbmZe3cUyhkKyJBTm5IEEQYDcPQLkEgb1ba/dFuJBKZcLIke6Ogsh7SVJpWVJcLM/LyFBYE3WlSTz7xF7Z+WWTfrYJQnme/bTt9mXLWcsrKEiAXu/ncB3LPkwmwZqUtHw2m0uTlWU/l5aTjt8tZWzZd0CFoiKdXWJUfi89L/vPpd+BQgH4+EhQqRy/O1tmSfyW/T8FAH5+KhQVhZabLyd9S+MuKXF8Po7OX15e/WyzViv9PZMIWq38rWdlKSpZk8gzzJ8fjFOnfCpfsRo6dCjBa6/pq73dkCFDoFQqAQB6vR5TpkzBuXPnIAgCSkpKHG4zYMAA+Pn5wc/PDzqdDjdu3Cg3uErXrl2t8zp27IhLly4hODgYzZo1Q3R0NAB5FOtPPvmkwvgOHz5sTWTcfffdyM7Ohl6vR8+ePbFw4UI8+OCDGDRoEJo0aYKuXbti+vTpMJlMuO+++9CpU6dqfx9EDZXJBBQUyJXwsu+WV0GBwu5OhfyynYb1DkbZaUlSoaREvkCzXAzZ3oG2vQgF7C8iLUmBwkIBoujKAU1DXLgve35+ElQqCT4+pReRpZ/t3zUaQK0W7S4uVSqp3LSPT+l8lUpOFpR+f+Xv7Nu2BCh7x1/eh/3+VCogJMQfRUX5Do+nVOLmS05MWKYtiQvLtCBIdstskxiWFhO2yQ3LPEfLW7TQwmissx8TkUtZEp225aNeD1y/rkJRkVyJk8tE23XkO8BGo+3d39K7wEVFctlXdr5lX2WTkpbKYsWVxoh6/26cC6t8lWpQKu3Lrooq95Z3f3+5HBZFEUplaSK2bPkmv9sulz+bzY6TFbY/F5MJyMtT2E3bsm1JZilfzWZVuflA+aRFYKDoIHHh+FzVagl+fvL/KPuX83m33mo/QGxteU0SQaORoFaLTCIQ1YDtI6befvtt9OnTBxs2bMClS5fw8MMPO9zGz8/P+lmpVMJsLt+NyHagRqVSCZPJ5PDxWJVx9kitF154AQMGDMB3332HoUOHYvPmzejduze+/PJL7NmzB5MnT8aECRPwyCOPVPuYRPXBbAby8wUYDALy8hQwGATk5ytuTpfOMxoF6wVjcbFgd/EoCCrk5WnLLJcvcCx37C2JgorublfE11eyeckXHJbPvr7yhUhgoAh/f8BsFstVHoGyFUnJpiIpL1OrpZv/y+V328+O5mk08nHlCm3pcUo/S9DpwpCVlWk3vzZdAoDSi1fLcatKHvk6q+YHdiGdTo2MjHx3h2EVGAgmEajWLMlI+9ZLqLBFU0GBosKkatl5loSAY9V/+pxaLUKtLl+xU6vlsjUgQITtnW5HSUqVSi6L5Xe5IhkcHIDCwjy7cliuFEvlEnqW+YB9ayZLKydn88omDgGpXDkrCEBoaCPk5uZYE4eAfdlvSVoqlXLSU6Gw/6xSlVb05Xk1L8M9qRwGPO3pDIArQ/GaJAIAaLUisrOZRCDvUJMWA/XBYDAgIkLOXtdF383WrVvjwoULuHTpEqKioqo0EGPv3r2xZcsWTJ06FQcPHoRWq0VQUBDOnz+PmJgYxMTE4OjRo0hLS4NarUZERARGjRqFgoICpKSkMIlAdcJslsfjMRgU0OsF6PUK6PUK5OaWn2cwCMjNVSAvT15mSRwUFFTtf5ajC0hfX8l6h4E5H4QAACAASURBVFuhUEClkucFBorW5b6+8t0X+Q6MXAG3fK7oXa22TxpU9YLN0y7QtFpAFGvZf4GIXEaS5MSpbdlZUKBAQYFgfTmq1MvLFHYV+qIiFfLzG1uTAs4r9xWTE5OitfyzlIWNGom49dbSpKUlcWlJnvr4lE6HhQWiqEhfZlnpZ7VaKpcsqE7ZWl06nQYZGZ7RvVunk5CR4bhVKzVcXpVECA2V2BKBqJYmTpyIKVOmYN26dbjrrrtcvn+NRoMlS5Zg1KhR0Gq16Nq1a6XbTJs2DdOmTUNcXBzUajWWL18OAFi/fj0OHjwIhUKBtm3bIjY2Ftu3b8eaNWugUqkQEBCAFStWuPwcqGGRJCAvT0BWlgLZ2fLL9nPZ6awsBQwGBfLyHD8b2VZAgIjgYAnBwSKCgiSEhYlo1syMoCARAQESgoJEBAZKN1/yOrafAwLk5T4V9HzypDsZRPT3UlQEpKaqcPq0D9LTldbkgMEgWBOolnfL/Kp2V1Kp7Cv1lkp+YKCI8HAJjRopoFAYb1bQLYlSQKOR7+6Xbclk+267T4ULqg46nT8yMtichshCkGrS9thFrl69Wq31R44MQ0GBgB07XHsx5UkXaJ4UC+BZ8XhDLAUFBXZdB+qLSqWCqWzHLDdRqVTIzc1FQEAAJEnC7Nmz0aJFCzz77LNuiaWy78XRz6zs2A8NXXXL4rpQ0d+30QjrHa28PIXdRazte16efDFreTcYBGRnK5CTo3DazF8Q5LtRoaESQkNFaLUiQkNFRET4wccnH8HBciIgJMTyLlrnBQXJTS/rmjeUfe7iSfEwFudqEg/L4folScDVqwpcuRKGQ4cKcfq0nDg4e1YFs7m0/FQqJQQFlSZO5XfRwTy5nAwOlhOnZVsC+PtXnDwFPOv32JNiATwrHsbinCfFU9NYnJXFXtUSQas148oV38pXJCK3+vTTT/H555+jpKQEnTp1wpgxY9wdEnk4SQLS0xVITVUhNVWFtDQVUlN9kJamwl9/KSvdXqMpvWiV3yU0bmxGaKhY7mVJFISGyskBpYPdy/9s8+rgTImI3Cs/X8Dvv8tJAvmlwu+/+yA313LL3geRkSbExJiQkGBETEwJYmJMaNrUDI1GqrMm+kTkPbwqicDuDETe4dlnn3VLywPyfKIIXLqktEkUyMmCs2d9kJNTOtJ0YKCINm1MuOeeIrRoYUKjRpY7WqXvlqRBZd0BiIhITtY+/HAYfv65dODkwEAR7dubMGxYIWJiSnDnnQGIiMhAcDDHGiEi57wqiaDVisjNlZ8j6ujOEREReabDh30xd24Izp5VwWgsvY2l05nRpo0JI0aIiIrKQ+vWJWjTxoSICJF3u4iIXKiwUMDPP/th4EAj/vGPfMTEmBAZabYra+W+/0wgEFHFvCyJYIYkySNga7Wiu8MhIqIq2rPHD7//rsLTT+ejTRsT2rQxoXXrEoSGyhercvcBz3kkHRFRQ6PXy9mCe+81Ij6+yM3REJE387Ikgpw4yMpiEoGIyJvk5ioQEiJiwQLPfPQpEVFDZzDIXYLZVYGIasurBhiw3LHiuAhERN7FYBB44UpE5Ea5uXJLhKAg3ogjotrxqtq4VmsGAGRne1XYRPXm4Ycfxr59++zmffDBB5g1a1aF25w4cQIAMGbMGOTm5pZbJzExEWvWrKnw2Lt27cIff/xhnX777bexf//+akTv2MGDB/H444/Xej/kXnq9AsHBvHAlInKX0pYILIuJqHa8qjYeGlranYGIynvggQewfft2u3nbt2/H8OHDq7T9xx9/jJCQkBodu2wSYcaMGejbt2+N9kUNj8EgICiILRGIiNzFMiYCW4URUW15VW1cq2V3BqKKDB48GMnJySgqkgdMunTpEq5fv4477rgDM2fOxKBBgxAbG4ulS5c63L5Xr17IysoCAKxYsQL33HMPHn30UZw9e9a6zqeffor7778fcXFxeOaZZ1BYWIgjR45g9+7deP3113Hvvffi/PnzmDJlCr7++msAwA8//ID4+HgMGDAA06ZNs8bXq1cvLF26FPfddx8GDBiAtLS0Cs8vOzsbY8eORVxcHIYMGYJTp04BAH766ScMHDgQAwcORHx8PPLy8nD9+nU88MADGDhwIO69914cOnSodl8u1YrBwJYIRETuZGmJwO4MRFRbXlUb12gkqNUiuzMQOaHVatG1a1drl4bt27dj2LBhEAQBr7zyCnbu3Ink5GT8/PPP1gq4I7/++it27NiBb7/9FuvXr7d2dwCAQYMG4b///S+Sk5PRunVr/Otf/0LPnj0xcOBAzJ07F9999x2aN29uXd9oNGLq1Kl4//33sWfPHphMJmzatMku5v/7v//DmDFjKu0ykZiYiE6dOiE5ORkzZ87E5MmTAQBr1qzBkiVLsHv3bmzduhVqtRpbt25F//79sXv3buzevRsdO3aswTdKrqLXsyUCEZE7GQxsiUBEruFVT2cA5Cc0sCUCeYPg+fPhU0FFvSZKOnSA/rXXKlxn+PDh2L59O+677z5s374dy5YtAwB89dVX+PTTT2E2m3H9+nWkpqaiQ4cODvdx6NAhJCQkQKPRAAAGDhxoXXbmzBm89dZb0Ov1yM/PR79+/SqM5+zZs4iOjkarVq0AAI888gg++ugjPPPMMwDkpAQAdO7cGTt37qxwX4cPH8YHH3wAALj77ruRnZ0NvV6Pnj17YuHChXjwwQcxaNAgNGnSBF27dsX06dNRXFyM++67D506dapw31S39HoF734REbmRXq+AQiEhIIBJBCKqHa+rjYeGSkwiEFUgISEBBw4cQEpKCoxGI2677TZcvHgRa9euxebNm5GcnIwBAwbAaDRWuB9BEBzOnzp1Kl5//XXs2bMHU6dOtXZNcEaSKr5Y8fPzAwAolUqYzeZq70sQBLzwwgt4++23YTQaMXToUKSlpaF3797Yvn07IiIiMHnyZHz++ecV7pvqjtkM5OUpePeLiMiNLGPTOPn3TkRUZWyJQFRHKmsxUFcCAgJw5513Ytq0adYBFQ0GAzQaDYKDg3Hjxg3s3bsXd955p9N99O7dG1OnTsXzzz8Ps9mM3bt3Y8yYMQCAvLw8NG7cGCUlJdi6dSsiIiIAAIGBgcjPzy+3r9atW+PSpUs4d+4cWrRogS+//BK9e/eu0bn17t0bW7ZswdSpU3Hw4EFotVoEBQXh/PnziImJQUxMDI4ePYq0tDSo1WpERkZi1KhRKCgoQEpKCh555JEaHZdqJy/P0oSWLRGIiNyFLcKIyFW8MIlgxpUrvu4Og8ijDR8+HOPGjcP7778PAOjYsSM6deqE2NhYREdHo2fPnhVuf9ttt2Ho0KGIj49HZGQkevXqZV02Y8YMDBkyBJGRkWjfvj3y8vIAyE+GmDFjBj788EOsXbvWur5arcayZcswfvx4mM1mdOnSxZqQqK5p06Zh2rRpiIuLg1qtxvLlywEA69evx8GDB6FQKNC2bVvExsZi+/btWLNmDVQqFQICArBixYoaHZNqj48VIyJyPz4lh4hcRZAqa2tch65evVrtbebMCcG2bRqcPPmXy+LQ6XTIyMhw2f5qw5NiATwrHm+IpaCgAP7+/vUej0qlgslkqvfjOuJtsTj6mTVp0qQuw/I4NSmLq+PUKRUGDgzHunVZGDzYcTcaT/r7BjwrHsbinCfFw1icq0k8LIdd7+GHwyCKwJYtmU7X8aTfHcbinCfFw1ic86R4ahqLs7LY6/oFaLUicnMFVNJ1moiIPAQfK0ZE5H65uRybhohcwyu7M0iSgNxcBbRaXpASEXm63Fw+VoyIvMfx48eRlJQEURQxYMAA6/hCFnl5eXj//fdx/fp1+Pj4YOLEiYiOjq7Stu4kd2fgtTMR1V6lSYTVq1fj2LFjCAkJQWJiosN1Tp48iY0bN8JsNiMoKAgLFy50eaAWoaHyRWhWFpMIRETegC0RiMhbiKKIDRs2YO7cuQgLC8OsWbPQo0cPREZGWtfZunUrmjdvjhkzZuDKlSvYsGED5s+fX6Vt3clgYEsEInKNSpMI/fv3R0JCAlatWuVweX5+PtavX485c+ZAp9MhNzfX5UHasiQO+IQG8kRuHGKEasjTfmYN8Q6YwSC3RAgJ8azvmoiorLS0NERERKBx48YAgD59+uDIkSN2iYDLly/jwQcfBAA0bdoUN27cQE5ODtLT0yvd1l0kiS0RiMh1Kk0idOjQAenp6U6XHzhwAL169YJOpwMAhISEuC46B7RaeTCE7GwmEcjzKBQKmEwmqFRe11Pob8lkMkGh8JyypKHeAdPr2RKBiLxDVlYWwsLCrNNhYWFITU21W6dZs2Y4dOgQ2rdvj7S0NNy4cQNZWVlV2tYiOTkZycnJAIA333zTeh1dV/LyALNZQESEBjqdn9P1VCpVncdSVYzFOU+Kh7E450nxuDqWWtd0rl27BpPJhFdffRWFhYW4//770a9fP1fE5pBtdwYiT6NWq2E0GlFUVARBEOrtuH5+figqKqq341XEW2KRJAkKhQJqtbqeo3Kuod4BMxgE+PlJ8HN+3UpE5BEctU4r+/98+PDh2LhxI2bMmIHo6Gi0aNECCoWiSttaxMXFIS4uzjpd1yO4X7umABABpTIPGRkFTtdrCKPJ1wVPigXwrHgYi3OeFI+rn85Q6ySC2WzGuXPnMG/ePBQXF2Pu3Llo06aNwwO6IutqeRJbUVEgdDrXPEqvIWeJasuT4mEsznnbYxXriyfFUhUN9Q5YcbESISGo8Die+DflKfEwFuc8KR7G4pynxVORsLAwZGaWPgIxMzMToaGhduv4+/vjueeeAyAnHV544QWEh4ejuLi40m3dxTI2TXAwW4QRUe3VOokQFhaGoKAgqNVqqNVqxMTE4MKFCw6TCK7KuqrVEbh82YiMDH2N47bVELJEdcWT4mEsznlSPA0hFnc9n7yh3gFLTw9FQIBPhcfxpN8bwLPiYSzOeVI8jMW5msTjrnK4VatWuHbtGtLT06HVanHw4EFMmjTJbp38/Hz4+flBpVJhz549iImJgb+/f5W2dRe9Xv5/EBTEsWmIqPZqnUTo0aMHPvzwQ5jNZphMJqSlpWHw4MGuiM2p0FCJ3RmIqMFpuHfABN79IiKvoFQqMXbsWCxevBiiKCI2NhZRUVH49ttvAQDx8fG4cuUK3nvvPSgUCkRGRmLChAkVbusJ+JQcInKlSpMIy5cvx6lTp2AwGDBhwgSMGDHC2jw4Pj4ekZGR6Nq1K1566SUoFArce++91pHC64pWKzKJQEQNTsO9A8bHihGR9+jWrRu6detmNy8+Pt76uW3btli5cmWVt/UElpYILIuJyBUqTSJMmTKl0p0MGzYMw4YNc0lAVaHVinw6AxE1OA33DpiAxo3N7g6DiOhvy/KUHLYKIyJX8Mrn0IWGirhyxcfdYRARuVzDvAOm4IUrEZEblQ6syJYIRFR7Xnk7n90ZiIi8h14vcDAvIiI30usFKJUS/P1ZFhNR7XllTVyrFZGbK8DM1rFERB7NZAIKCtgSgYjInQwGBYKCJDh5aA8RUbV4ZRIhNFSEJAnIzfXK8ImI/jYMBj5WjIjI3eQWYUzmEpFreGUtXKuVC0F2aSAi8myl/XB58UpE5C6WlghERK7glbVwSxKBT2ggIvJsfKwYEZH7GQwCk7lE5DJeWQsPDWVLBCIib2BpicBmtERE7qPXsyUCEbmOV9bC2Z2BiMg7lD6bnBevRETuYjBwTAQich2VuwOoCXZnICLyDpbuDLx4JSJyH4NBwWSuJ5AkoLgYQlERhKIieRoABAHWR2fYfLb+xMou9/GBoNeXzrd5ldvG9lVSAqGwsPRlNEJhO+3khZISQJIgiKIcs81L6eeHEKPRbp5w811SKAA/P0hqNSTLu+WzRlO6rOxyHx8IACCK8kuSrO+CZd7Nl2BZJooQgoLgm5NTGoflO7d92Z4DYI0VkgSYzU6PA0mCYFluu47ZDJjNdp8hihBEEUo/PwTl5cnb2S4zmyEplYCvLyQfH0h+foCPDyRfX/vPvr7yOjfXg5+fHHNREXDzd0i4+ftknb45r+y0MiQEePVVl/0qe2USQaORoFZLbIlAROThLN0ZQkJ48UpE5A6SJCd0G+SYCJIkP0vYZIJgMsmVZMu75XNxsd28cuuUnVdmfzCbofTxQZBeX7rs5nyhpESeLiqCYDSWJgfKTAtFRYBlWnLN/8NbXbKXyolqNeDrCyjk/+dSmcSEQqmEWpLKJTokQZAr1pbvwmh02blXRFfnR6g6SaFAoFIJKJVyQsXmsyCK8u+m5ffT1cf287MmJSRfXwgRES7dv1cmEQB5XAQmEYiIPBtbIhARuVd+vgBRdGESoaQEQkGB/MrPl+9k5+dbpy3LFJbPRmNpxbvsu6USbzvfZJLvnEoSwo1G+e5t2Ur+zfe6qHw5IikUCPTxke8e+/hAUqkAlUp+v3kn2frSaCA1alQ6ffPuOmzXUavlu8wKhd1dcflgNnfILdNlPgcEBCA/L89uvuBgvXIvX185PgcvUaOR47Sd7+dnTR44o9PpkJGRUYUvUZJ/brZJBUtypbDQPhFTXCxXui2JCYXC+pLKTNvOC2nUCLkOWmhIQOl+HLXesD2OUlnpcSzrQBDKJQcsn6FQVP27sU0olJTIiZeSktIWBZbPxcXy92hpuWFpuWD5vbJM+/qWJnRsfk6oSixV5LVJBK1WRHa2UPmKRETkNgaDAmq1CB8fd0dCRPT3VJrMrcJdYLMZykuXoDp3Dso//4Tq3DnrS5GVJScFiourfGxJEKyVGmuFu+y7j49cIffxAXx9IQYEAD4+UAYEoEQUSyvslvXKbm9bsbe82x7Pcoyyx3S0rqN9qlTQhYdXrTJYTzQ6HfI9KJ4qEYTSpvlBQXVyCEmnQ7G3fS+AnJCwdOVwdyxV5LVJBLklgtLdYRARUQXkx4p5y79EIqKGp9xTciQJir/+Kk0Q/PknlJbPFy6gcVGRdVtRo4G5RQuUxMRAvOUWiAEBkPz95dfNz2JAgHzX2rLMMt/fH1Cry90RrSqdTodsb6wQEv0NeG0SQasV8dtvvLVFROTJcnMV7MpARORGlpYIWl8DtKOfgu/PP0NRWGhdLvn5wdS8OUwtW0IxZAgMEREwtWgBU8uWEBs3rnESgIgaLq9OIrA7AxGRZ2NLBCIi95JbIki4a9M0+B34HvlPPglT69YwtWgBc8uWMDdpYu33rtPpUMC7/0RUCa9NIoSGisjJUcBslseuICIiz6PXKxrmiOBERF7CYBDwLNYhcv8W6F9+GXmTJ7s7JCLycl77eAOtVoQkCcjN9dpTICJq8AwGoWqDeRERUZ3QnE7BSkxCbp9Y5L34orvDIaIGwGtr4FqtfGeLj3kkIvJcBgNbIhARuYuQm4thHz+JdIQjY9nKSh/XR0RUFV5bkoSGyhel2dleewpERA1ebi5bIhARuYUkodG0aQjRX8Zjis1QR2rdHRERNRBeOyYCWyIQEXm2khLAaOTTGTyKKEIwGuUfjlIpPwvd8lIo6ncUdrNZft58cTGEkhKgqAhCSUnpPMv8CgghIfDNzXW4TPLxkZ+57ecHSa0GNBp5Wq32/LuxkgSIovwdmc2AzUu4OR9mMwRJKl1XFEs/Z2ZClZVlP0+0+Tu0PI9co5FfrvpObv5+CUYjhMJCoLBQ/n2LieEAVm4QsG4dNLt24bMeb+JkWm8Iwl/uDomIGggmEYiIqE5Ynk3uFU9nkCT7SlpBAWB5BJoglL7KTtvOA+SKWkkJBJOp9N1ksp8uKZErhmXXKy4unbZ8Li6GwtcXAbm5pZXqkpLS96Ki0krbzc+wTJeZLxiNcgW9oq/hZkJBUijkSp9KVfpZqYTCxwfhYvWTQoIoyt+DbYKgBvtxRFeDbSRfX2tyoewLgiD/fCwxWz6bzfLPxEHlXjCbIQgCIqQa/K7bJgVsfwdrKbya61u/D0uypey7Wi3/Lt1MDJR7v/lyxLRsGfDoo7U+J6o6nyNHELxkCQoHDcKX6hcQnM5kLhG5jtcmEdidgYjIs1meTV6bMRGEwkIor1yBYDBAyMuDIj8fQl6e/LmgwPpZyM+H4ua7kJcnfy4sLK2wWyqEthW2m/Osd3TLaFLjqF0vxOazpFJBUqkAX1+5MnzzbjtsKsJicLDDCrKkVsvrqVTyXWOzWf4OLJ/LVGYhinLF+eZntY8Pip1UFCsiCQLg4wPJ11eO2/bzzWm7z35+8jo+PhW2jggJCUGuo5YIkiS3aiibRHGUZCnzgiTJFWqVClAo7FprSDatNiSVqrQFh1IJtb8/Cmvw3UAQ5H2oVPL+b+6v3HHLzlco5DgsLUgs+xEEBIWEQJ+XVzrPso5CISfMLMkA20RABZ8VN25AKCqyJhrEwEBIt9xiTTKgTKuGsp8D77qr+t+LGx0/fhxJSUkQRREDBgzA8OHD7ZYXFBRg5cqVyMzMhNlsxtChQxEbGwsA+Prrr/Hdd99BEARERUXhueeeg6+vb73Gr8jKgnbiRJibNkVOYiL0k5TsVkZELuW1SQSNRoJaLbElAhGRh6pySwRRBM6fh9///gfVn39CdfYsVGfPQvnnn1BduVLhppIgQAoMhBQQIFdsbn42RUVBCggorZg5qIyVq6jZzPcPCEBBfr5c4bK8gPLTN+dZmpVLlrv3Pj7yu0pVftrHp3S+7bSlAn2z8mz5rI2IQKbBYF3XnU3xfXQ65HjQM+QlnQ7FHhKPj04HvYfEEqDTweghsQBAoE4HeFA8FRFFERs2bMDcuXMRFhaGWbNmoUePHoiMjLSus2vXLkRGRmLmzJnQ6/WYPHky7rnnHuj1euzcuRPvvPMOfH19sWzZMhw8eBD9+/evzxNAoxdfhCIrCzd27IAUEgKDQeAAt0TkUl6bRBAEuTUCkwhERJ7J0hLBMiaCkJ1dmiSwfT93DkJREcJubicGBsLUqhWK77gDBa1awRwdLd9Zv5kkEAMCrJ8ljaZO+vGrdTrkeUqlR6uF5KKm/0RUsbS0NERERKBx48YAgD59+uDIkSN2SQRBEGA0GiFJEoxGIwIDA6G4mdwTRRHFxcVQKpUoLi5GaGhovcYfuHIl1Pv2Ieef/4SpUycAgF6vQFSUqV7jIKKGrdIkwurVq3Hs2DGEhIQgMTHR6XppaWmYM2cOpk6dit69e7s0SGdCQ0VkZ9fjIFBERFRler2lJYKIwNWrEbx4sXWZpFTC3KwZTC1boqhfP6g7d0ZO48YwtWoF8ZZb6neAPyKim7KyshAWFmadDgsLQ2pqqt06CQkJeOuttzB+/HgUFhZi6tSpUCgU0Gq1GDp0KCZOnAhfX1906dIFXbp0cXic5ORkJCcnAwDefPNN6HQ1Gd3DnrB3L1SJiTA/9hj8J0+G/81ytKBAhVtuUVTpGCqVyiWxuAJjcc6T4mEsznlSPK6OpdIkQv/+/ZGQkIBVq1Y5XUcURXz66afo2rWrywKrCq1WRFYWR/slIvJElpYIt146iqA334QxLg75o0bB1LIlzM2ayU3zb/L1oGbpRPT3JTkYH0Uok9Q8ceIEmjVrhvnz5+P69etYtGgR2rdvD1EUceTIEaxatQr+/v5YtmwZ9u/fj759+5bbZ1xcHOLi4qzTGbUs/xTXr+OWMWNgatUKGQsXQsrMtC7LyYmAr28hMjL0le5Hp9PVOhZXYSzOeVI8jMU5T4qnprE0aeJ4hKhK+wJ06NABgYGBFa6zc+dO9OrVC8HBwdUOrDbkJAK7MxAReSKDQQENCtD29RdgbtwY2StXoig+HubWre0SCEREniIsLAyZNhXwzMzMcl0S9u7di169eslP5IiIQHh4OK5evYqUlBSEh4cjODgYKpUKvXr1wh9//FH3QZtMCH3uOQh5echet04eD+YmSQIMBoEDKxKRS9V6TISsrCwcPnwYCxYswPvvv++KmKqM3RmIqKHx9lHBbRkMAt7Cy/A7/ycyNm+GFBJS6TZERO7UqlUrXLt2Denp6dBqtTh48CAmTZpkt45Op0NKSgpiYmKQk5ODq1evIjw8HJIkITU1FUVFRfD19UVKSgpatWpV5zEHvf02/H7+GdkrV8LUtq3dsvx8AaLIgRWJyLVqnUTYuHEjRo0aZR1QpiKu7v8VGalETo4CoaE6KGvRq6Eh91epLU+Kh7E450nxMJaa8/pRwcuIPPkdXsAq5D3zDIrvvtttcRARVZVSqcTYsWOxePFiiKKI2NhYREVF4dtvvwUAxMfH46GHHsLq1asxffp0AMCoUaMQHByM4OBg9O7dG6+88gqUSiWaN29u12WhLvglJyPovfeQP2oUCh96qNzy0kftsiUCEblOrZMIZ8+exYoVKwAAer0ev/zyCxQKBe64445y67q6/5daHQBJCsHZs1nQamueYW0I/VXqiifFw1ic86R4GkIszvp/1TVvHxXclpCdjcf3TcQZVQcEzZzptjiIiKqrW7du6Natm928+Ph462etVou5c+c63HbEiBEYMWJEncZnobx8GaGTJ6OkY0fkvvaaw3UsA9xanpJDROQKtU4i2A64uGrVKnTv3t1hAqEuhIbKBWJWlgCttl4OSURUZ+prVPD60Gj2bPgYM/Bk5Ha8r1a7LQ4iogapuBihEyYAZjOy1q4FnJSzBoPlKTlsiUBErlNpEmH58uU4deoUDAYDJkyYgBEjRsBkkp81a5uVdQdL64PsbCUAs1tjISKqrfoaFbwuHi1mS7F5M1Q7dmBDy9dx/ZYe0Okqfz65p3U98aR4GItznhQPY3HO0+JpCIJffx2+v/yCrHXrYG7Rwul6lu4MbIlARK5UaRJhypQpVd7Z888/X6tgqsuSROATGoioIajqqODDhw8vNyr4jRs3rKOCA7COCl4fjxazpbh6FeEvvoji7t3xvmkqgjTFyMjIqnQ7T+oGA3hWPIzFOU+Kh7E4V5N43NWtzBv4/PorAjdsQN7TT8M4eHCFeZVUCAAAIABJREFU67IlAhHVBa+ufVu6M/AJDUTUENiOCm4ymXDw4EH06NHDbh3LqOAA7EYF1+l01lHBJUlCSkoKmjZtWr8nIIoInToVKClB9ooVyDb48sKViMjFSjp3RmZSEvROxmWwxZYIRFQXaj0mgjuVtkSoxaMZiIg8hLeNCl5WQFIS/A4cQM4//wlzixY3n03OC1ciIlcrqmKXYrZEIKK64NVJBI1GglotsTsDETUY3jIqeFmq1FQEL1kC44ABKBg1CoA8KjgvXImI3EevF6BUStBoWBYTket4de1bEIBGjUR2ZyAicqeSEjSaNAmiRoOcpUsBQUBREVBUxJYIRETuZDAoEBQkQeClMhG5kFe3RADkLg1siUBE5D5By5fD99dfkfXBBxDDwwHYNqFlEoGIyF0MBoHlMBG5nNfXvuUkAsdEICJyB5+jRxH47rsoePhhGO+/3zq/dDAvNqElInIXuVsZkwhE5FoNIonA7gxERPVPKChA6KRJMEdEIHfRIrtlbIlAROR+er3AZC4RuZzXd2cIDWV3BiIidwhetAjKCxeQ+Z//QAoOtltmaYnAgRWJiNzHYFAgOtrk7jCIqIHx+tq3VisiJ0cBs9ndkRAR/X34ffcdAjZtQv4zz6C4T59yy/V6+d8LB1YkInIftkQgorrQIJIIkiQgN5ddGoiI6oOQlYVG06ejpF076F95xeE6BgNbIhARuZvBwDERiMj1vD6JEBoqF4zs0kBEVA8kCY1mzoQiOxvZK1cCarXD1dgSgYjIvURRTuiyJQIRuZrX17y1WvkCNTubT2ggIqprmi1boPnmGxheegmmTp2crmcZWJEXr0RE7pGfL0CS+IhHInK9BpREYHcGIqK65vPbbyjq2RN5EydWuJ5eLyAwUISS+V0iIrfgo3aJqK40iKczAOzOQERUH/QLFgCFhagsO2AwKHjhSkTkRqUtwtgSgYhcy+tr3paWCFlZvN1FRFQvNJpKV9Hr2YSWiMidLEmEkBAmdInItbw+iaDRSFCrJbZEICLyIHo9WyIQEblTaXcGJnSJyLW8vuYtCECjRiLHRCAi8iAGA1siEBG5k+UpOXzULhG5mtcnEQC5SwNbIhAReQ69ns8mJyJyJ7ZEIKK64vUDKwKWJALHRCAi8hR8NjkReavjx48jKSkJoihiwIABGD58uN3ygoICrFy5EpmZmTCbzRg6dChiY2MBAPn5+VizZg0uXboEQRAwceJEtG3b1h2nYR0TgS0RiMjVGkQSITRUxKlTDeJUiIi8niTJF69siUBE3kYURWzYsAFz585FWFgYZs2ahR49eiAyMtK6zq5duxAZGYmZM2dCr9dj8uTJuOeee6BSqZCUlISuXbti+vTpMJlMKCoqctu5GAwCVCp57DAiIldqEH0A2J2BiMhzGI1AcTFbIhCR90lLS0NERAQaN24MlUqFPn364MiRI3brCIIAo9EISZJgNBoRGBgIhUKBgoICnD59Gvfeey8AQKVSISAgwB2nAcAywK0IgcOGEZGLNYjb91qtiJwcBczmSh9dTkREdYzPJicib5WVlYWwsDDrdFhYGFJTU+3WSUhIwFtvvYXx48ejsLAQU6dOhUKhQHp6OoKDg7F69WpcuHABLVu2xJNPPgm1Wl3fpwHAMsAtk7lE5HoNIokQGipCkgTk5grQallYEhG5k2UwL168EpG3kaTy5ZZQ5lb+iRMn0KxZM8yfPx/Xr1/HokWL0L59e5jNZpw7dw5jx45FmzZtkJSUhG3btmHkyJHl9pmcnIzk5GQAwJtvvgmdTufyczEaVQgNRbX2rVKp6iSWmmAsznlSPIzFOU+Kx9WxNIgkglYr3+3KylJAqzW7ORoior+30sG82BKBiLxLWFgYMjMzrdOZmZkIDQ21W2fv3r0YPnw4BEFAREQEwsPDcfXqVeh0OoSFhaFNmzYAgN69e2Pbtm0OjxMXF4e4uDjrdEZGhsvPJTMzDBoNkJGRWfnKN+l0ujqJpSYYi3OeFA9jcc6T4qlpLE2aNHE4v0EMJGBJImRnsy8DEZG7cURwIvJWrVq1wrVr15Ceng6TyYSDBw+iR48eduvodDqkpKQAAHJycnD16lWEh4ejUaNGCAsLw9WrVwEAKSkpdgMy1jeDQYGQECZzicj1Km2JsHr1ahw7dgwhISFITEwst/yHH37A9u3bAQBqtRrjxo1D8+bNXR5oRUJDLUkEjhxDRORuubl8NjkReSelUomxY8di8eLFEEURsbGxiIqKwrfffgsAiI+Px0MPPYTVq1dj+vTpAIBRo0YhODgYADB27FisXLkSJpMJ4eHheO6559x2Lno9B7glorpRaRKhf//+SEhIwKpVqxwuDw8Px6uvvorAwED88ssvWLduHZYsWeLyQCti252BiIjciy0RiMibdev2/+zdeXhTdb4/8PdJQndakhPa2IWlBUVxQHs7A1NltDZWUKidYS4ujHekw4iiov6qDwUKLsCIIqCdkcGrnfpwr9dxR8aFqVWuOFQvdRQsIkuBYYB2WprQJl3SNjnn90dIILShW5KThPfrefqQsyWfIJ6e8zmf7/eTiczMTI91eXl57tc6nQ4lJSW9HjtmzBisWbPGr/H1l8XCVrtE5B99JhGuuOIKNDY2et1+2WWXuV+PHz/eYxxZoJxNInA4AxGR0lwTK7ISgYhIGZIEtLayEoGI/MOnj+4/++wzXH311b58y36JjpYRGSlzOAMRURCwWlUQBBlxcbx4JSJSQmurAFkWmMwlIr/wWXeGvXv3Yvv27Xjqqae87uPPdjZ6PdDeHgO9PnLAx4Zz+42hCqZ4GIt3wRQPYxma3bt3o7y8HJIkITc3FwUFBR7b29vbUVpaCpPJBIfDgVmzZiEnJwcA0NbWhk2bNuH48eMQBAH33XcfLr300oB/B6vV+fRLxRFmRESK4LAyIvInnyQRjh07hpdeeglLlizB8OHDve7nz3Y2CQkjUVdnR1PT6QEfGw7tN/wlmOJhLN4FUzzhEIu3djb+JkkSysrKUFJSAlEUsWTJEmRlZXnM7r1t2zakpqaiuLgYFosFDz30EKZNmwaNRoPy8nJcddVVKCoqgt1uR2dnpyLfw2JR8ekXEZGCOKyMiPxpyM+Jmpqa8Nxzz+GBBx7w74W3LEN16hSE1tZeN2u1Ek6f5mMvIgpdtbW1MBgMSEpKgkajQXZ2Nqqrqz32EQQBNpsNsizDZrMhLi4OKpUK7e3t+OGHH3DDDTcAcFZhxMbGKvE1YLEIfPpFRKQgViIQkT/1WYnw/PPPY9++fbBarbj33nsxZ84c2O12AM6Zat9++220trbilVdeAeBsjeOPWWk1hw8j8brrcLq0FB2zZ/fYrtNJ2LfPZ6MziIgCzmw2QxRF97Ioijh06JDHPtOnT8ezzz6LBQsWoKOjA4888ghUKhUaGxsRHx+PjRs34tixY0hPT8fdd9+NqKioQH8NViIQESmMlQhE5E993nU//PDDF9x+77334t577/VZQN7YR42CrFJBc/hwr9t1OoktHokopMlyzydGguA5YeyePXswevRorFixAg0NDVi5ciUmTJgAh8OBo0ePorCwEOPHj0d5eTm2bNmC22+/vcd7+nN+GgDo6NDgkkswoPcNtvkrgikexuJdMMXDWLwLtnguBqxEICJ/Cp1H9xERcIwaBc2RI71u1moltLSo4HAAanZ6JKIQJIqiR5tck8kErVbrsc/27dtRUFAAQRBgMBiQmJiIuro66PV6iKKI8ePHAwCmTp2KLVu29Po5/pyfBgBOn07E2LFdaGpq7vcxwTSXBhBc8TAW74IpHsbi3WDiUWpumnDhqkSIj2clAhH5Xkg9urenp3tNIuh0EiRJQEsL2zwSUWjKyMhAfX09GhsbYbfbUVVVhaysLI999Ho9ampqAADNzc2oq6tDYmIiRowYAVEUUVdXBwCoqanxmJAxkDgnAhGRslyVCBzOQET+EDqVCHAmESK+/BKQZeC8El+dznmSNJtV0OkcSoRHRDQkarUahYWFWL16NSRJQk5ODtLS0lBRUQHAOQ/N7NmzsXHjRhQVFQEA5s6di/j4eABAYWEhSktLYbfbkZiYiIULFwb8O8iy8+KVF65ERMqxWAQMGyZDgWlxiOgiEHJJBFVHB1T19ZDOK3PTap0XrM4ODUwiEFFoyszMRGZmpse6vLw892udToeSkpJejx0zZoxfJrYdiI4OAXY7KxGIiJTkmuBWYIEuEflByA1nANDrkAZXJQLbPBIRKYczghMRKc9qZTKXiPwnpO647RkZAC6cRGCHBiIi5XBGcCIi5bHVLhH5U0jdcUsGA6To6F7bPHoOZyAiIiWwEoGISHlWq4Dhw5nMJSL/CK07bpUKjrFje61EiImRERkpsxKBiEhBZysRmEQgIlKK1arieZiI/Cbk7ri9tXkUBGc1ApMIRETKcbXZ5XAGIiLlWCysRCAi/wm5O257RgbUx48DXV09tmm1EoczEBEpiL3JiYiUx0oEIvKnkLvjtqenQ3A4oPnnP3ts0+lYiUBEpCSrlZUIRERKkiSgtZXdGYjIf0LujtvV5lHtpUMDkwhERMqxWFRQqWTExvLilYhICa2tAmRZYEUYEflNyN1xu5IIvc2LwDkRiIiU5epNLghKR0JEdHGyWNhql4j8K+TuuOURI+AQxV6TCDqdhJYWFRwOBQIjIiL2JiciUhhb7RKRv4VcEgE406Hh8OEe63U6CZIkuGcHJyKiwHImEfj0i4hIKWdb7fJcTET+oVE6gMFwpKcjcvv2Huu1WmfG1WxWQadjOQIRUaA5hzPw6RcRha7du3ejvLwckiQhNzcXBQUFHtvb29tRWloKk8kEh8OBWbNmIScnx71dkiQUFxdDp9OhuLg40OGzEoGI/C40KxEyMqBubIRgtXqs1+mcJ0u2eSQiUgYrEYgolEmShLKyMixduhQbNmzAzp07ceLECY99tm3bhtTUVKxduxZPPPEENm/eDLvd7t7+0UcfISUlJdChu7HVLhH5W0jebbsnVzx61GM9kwhERMqyWjkjOBGFrtraWhgMBiQlJUGj0SA7OxvV1dUe+wiCAJvNBlmWYbPZEBcXB5XKee1pMpnwzTffIDc3V4nwAZytROBwBiLyl5C823YnEc6bF+Hc4QxERBR4VqsKCQlMIhBRaDKbzRBF0b0siiLMZrPHPtOnT8fJkyexYMECFBUVYd68ee4kwquvvopf/epXEBRsUcNKBCLyt5CcE8E+ejRkQejRoYGVCEREypFl5xMwDmcgolAlyz3PX+cnBPbs2YPRo0djxYoVaGhowMqVKzFhwgT88MMPSEhIQHp6Or7//vsLfk5lZSUqKysBAGvWrIFer/fZd7Db1YiIkJGaqh9wu12NRuPTWIaCsXgXTPEwFu+CKR5fxxKSSQRERcGRlgb1eUmEmBgZkZEyKxGIiBTQ1iZAkjixIhGFLlEUYTKZ3MsmkwlardZjn+3bt6OgoACCIMBgMCAxMRF1dXU4cOAAvv76a3z77bfo6upCR0cHSktLsWjRoh6fYzQaYTQa3ctNTU0++w4NDQkYPjwKJtPA31Ov1/s0lqFgLN4FUzyMxbtgimewsSQnJ/e6PjSTCOi9zaMgOIc0MIlARBR4Z2cEZyUCEYWmjIwM1NfXo7GxETqdDlVVVT2SAHq9HjU1Nbj88svR3NyMuro6JCYm4s4778Sdd94JAPj+++/xl7/8pdcEgr8556bheZiI/Cekkwgx1dXO+tlzarW0WonDGYiIFMBxuEQU6tRqNQoLC7F69WpIkoScnBykpaWhoqICAJCXl4fZs2dj48aNKCoqAgDMnTsX8fHxSobtwWJRsSKMiPwqpJMIqrY2qBobISUludfrdKxEICJSAmcEJ6JwkJmZiczMTI91eXl57tc6nQ4lJSUXfI+JEydi4sSJfomvL2y1S0T+1mcSYePGjfjmm2+QkJCAdevW9dguyzLKy8vx7bffIjIyEgsXLkT6me4J/uTIyAAAaI4cQdc5SQStVsIPP4RsboSIKGS5KhH4BIyISDlWq4CRIx1Kh0FEYazPR/bXX389li5d6nX7t99+i3/9618oLS3FPffcg1deecWnAXrjrc2jTsfhDERESrBaWYlARKQ0ViIQkb/1ebd9xRVXIC4uzuv2r7/+Gj/72c8gCAIuvfRStLW14fTp0z4NsjeO5GTIUVG9tnlsblbBwQQsEVFAtbRwTgQiIqU5J1bkeZiI/GfIj+zNZrNHz0lRFGE2m4f6tn1TqWAfO7ZHEkGrlSBJAlpaBtgYl4iIhuTscAY+ASMiUoLDAbS2qngeJiK/GvLkAbLc8yQlCL3fwFdWVqKyshIAsGbNGo/kw2CoJ0yA5vvvPd5n9GhXXkREf99eo9EMORZfCaZYgOCKh7F4F0zxMJaLl8UiQK2WER3Ni1ciIiW0trpa7bISgYj8Z8hJBFEU0dTU5F42mUzQarW97ms0GmE0Gt3L5x43GMNTUhD3l7+gqb4eGDYMADBsWCQAEYcPt0Cn6+7X++j1+iHH4ivBFAsQXPEwFu+CKZ5wiCU5OdkP0YQ/q9U5DtdLHpmIiPzMVRGWkMAkAhH5z5CHM2RlZWHHjh2QZRkHDx5ETEyM1ySCr9nT0yHY7VAfP+5ep9M5T5qcXJGIKLCsVoEXrkRECnK12uXEikTkT31WIjz//PPYt28frFYr7r33XsyZMwd2ux2As2fu1VdfjW+++QaLFi1CREQEFi5c6PegXezntHl0nOnWoNUyiUBEoWv37t0oLy+HJEnIzc1FQUGBx/b29naUlpbCZDLB4XBg1qxZyMnJcW+XJAnFxcXQ6XQoLi4OaOwtLSqW0BIRKchVicBzMRH5U59JhIcffviC2wVBwPz5830W0EC42zweOYLOM+tclQhmM5MIRBRaJElCWVkZSkpKIIoilixZgqysLKSmprr32bZtG1JTU1FcXAyLxYKHHnoI06ZNg0bjPJ1/9NFHSElJQUdHR8Djd84IzqdfRERKcU0szokVicifQvpOW9bpII0YAc3hw+51MTEyIiNlJhGIKOTU1tbCYDAgKSkJGo0G2dnZqK6u9thHEATYbDbIsgybzYa4uDioVM7znclkwjfffIPc3FwlwofVqkJ8PJ9+EREphZUIRBQIIX+nbU9P92jzKAjOIQ0czkBEocZsNkMURfdyby1zp0+fjpMnT2LBggUoKirCvHnz3EmEV199Fb/61a+8dsjxN4uFlQhEREqyWlmJQET+N+TuDEqzZ2Qg8osvPNZptRIrEYgo5PSnZe6ePXswevRorFixAg0NDVi5ciUmTJiAH374AQkJCUhPT8f3339/wc/xdbtdl9ZWNRITIwf1fsHWjjOY4mEs3gVTPIzFu2CLJ5xZLKxEICL/C/0kQno6Yt56C0JbG+TYWADOeRGYRCCiUCOKIkwmk3u5t5a527dvR0FBAQRBgMFgQGJiIurq6nDgwAF8/fXX+Pbbb9HV1YWOjg6UlpZi0aJFPT7H1+12AUCSAIvlEkREtKOpyTrg44OpNSgQXPEwFu+CKR7G4t1g4mGr3cGxWgVERMiIilI6EiIKZyF/p+2aXFF99Kh7HYczEFEoysjIQH19PRobG2G321FVVYWsrCyPffR6PWpqagAAzc3NqKurQ2JiIu68805s2rQJL774Ih5++GFceeWVvSYQ/KW1VYAsC3z6RUSkIIuFXXKIyP9CvxLB1ebx8GHYr7wSACsRiCg0qdVqFBYWYvXq1ZAkCTk5OUhLS0NFRQUAZ1vd2bNnY+PGjSgqKgIAzJ07F/Hx8UqGDeDsZF4ch0tEpByrVeB5mIj8LvSTCGPGAIDH5Io6nYTmZhUkCVAxl0BEISQzMxOZmZke6/Ly8tyvdTodSkpKLvgeEydOxMSJE/0SnzcWi3PuBj4BIyJSDrvkEFEghP4tdnQ07CkpHkkErVaCJAnuXrlERORfrEQgIlKeczgDz8NE5F+hn0QA4DivzaNO58zAckgDEVFguCoR+ASMiEg5zuEMPA8TkX+FxV22PSPDmUQ40x6NSQQiosByVSJwOAMRkXJaWliJQET+FxZ32fb0dKgsFqjOtEbTap0XsezQQEQUGK7hYxzOQESkHKuVXXKIyP/C4i7b1eZRc/gwgLOVCEwiEBEFBisRiIiU5XAAbW0qJnOJyO/C4i7bnUQ4My8ChzMQEQWW1Spg2DAZUVFKR0JEdHGyWtklh4gCI+RbPAKAIzUVckQE1GeSCDExMiIiZCYRiIgCxDkjuASBTXGIKMTt3r0b5eXlkCQJubm5KCgo8Nje3t6O0tJSmEwmOBwOzJo1Czk5OWhqasKLL76I5uZmCIIAo9GIm2++OWBxn+2SwyQCEflXWCQRoFbDPmaMuxJBEJzVCBzOQEQUGM4ZwVlCS0ShTZIklJWVoaSkBKIoYsmSJcjKykJqaqp7n23btiE1NRXFxcWwWCx46KGHMG3aNKjVatx1111IT09HR0cHiouLMWnSJI9j/cnVJYcTKxKRv4XNXbY9Pd09JwLgnFyRlQhERIFhsaj49IuIQl5tbS0MBgOSkpKg0WiQnZ2N6upqj30EQYDNZoMsy7DZbIiLi4NKpYJWq0X6mSG20dHRSElJgdlsDljsrEQgokAJm7tse0YGNP/4h3NWGTCJQEQUSM7hDHz6RUShzWw2QxRF97Ioij0SAdOnT8fJkyexYMECFBUVYd68eVCpPK85GxsbcfToUYwbNy4gcQNnKxFYFUZE/hYewxngrEQQuruhPnECjtGjodNJ2L8/bL4eEVFQs1oFjBzpUDoMIqIhkeWeN+DCeZO97NmzB6NHj8aKFSvQ0NCAlStXYsKECYiJiQEA2Gw2rFu3Dnfffbd73fkqKytRWVkJAFizZg30er0PoncmMkaNSsBg306j0fgolqFjLN4FUzyMxbtgisfXsYTNXbbjnDaPriQCKxGIiAKDlQhEFA5EUYTJZHIvm0wmaLVaj322b9+OgoICCIIAg8GAxMRE1NXVYdy4cbDb7Vi3bh2mTZuGKVOmeP0co9EIo9HoXm5qahpy7HV1MQBGwOEwo6lpcEMa9Hq9T2LxBcbiXTDFw1i8C6Z4BhtLcnJyr+vD5i77/DaPWq2E5mYVJA4LIyLyO6tVYFsxIgp5GRkZqK+vR2NjI+x2O6qqqpCVleWxj16vR01NDQCgubkZdXV1SExMhCzL2LRpE1JSUjBz5syAx97S4rys57mYiPwtbCoRJFGElJDgTiLodBIkSUBLiwCtlk/HiIj8xeEAWltVSEjguZaIQptarUZhYSFWr14NSZKQk5ODtLQ0VFRUAADy8vIwe/ZsbNy4EUVFRQCAuXPnIj4+Hvv378eOHTswatQoPPbYYwCAO+64A5mZmQGJ3WpVITJSRmRkQD6OiC5iYZNEgCA4OzSck0QAALNZBa2W43SJiPzFanW1FePTLyIKfZmZmT1u/PPy8tyvdTodSkpKehw3YcIEvPnmm36PzxuLhRVhRBQYYTOcAQDsY8dCfabNo1Z7NolARET+w7ZiRETKs1o5Nw0RBUZY3WHb09OhqauD0NHhrkQ4fTqsviIRUdBxtRXjxSsRkXKsVoHJXCIKiLC6w7ZnZAAA1EePMolARBQgrkoEltESESmHXXKIKFD6NSfC7t27UV5eDkmSkJubi4KCAo/t7e3tKC0thclkgsPhwKxZs5CTk+OXgC/k3A4N2usnAuBwBiIif3NVIsTH8+KViEgpVquApCTOA0ZE/tfnHbYkSSgrK8PSpUuxYcMG7Ny5EydOnPDYZ9u2bUhNTcXatWvxxBNPYPPmzbDb7X4L2hvH2LEAAM3hw4iNlRERIbMSgYjIzzgnAhGR8iwWFc/DRBQQfd5h19bWwmAwICkpCRqNBtnZ2aiurvbYRxAE2Gw2yLIMm82GuLg4qFSBv3mXY2PhMBigOXIEguDs0MBKBCIi/2IlAhGR8qxWgcMZiCgg+rzDNpvNEEXRvSyKIsxms8c+06dPx8mTJ7FgwQIUFRVh3rx5iiQRAOe8CK42j1otkwhERP5msXBOBCIiJdntQFsbKxGIKDD6nBNBlntmNAVB8Fjes2cPRo8ejRUrVqChoQErV67EhAkTEBMT47FfZWUlKisrAQBr1qyBXq8fSuy9Ul9xBVTvvAO9Xo+kJDVaW9V9fo5Go/FLLIMRTLEAwRUPY/EumOJhLBcfq1WFyEgZkZFKR0JEdHGyWtklh4gCp88kgiiKMJlM7mWTyQStVuuxz/bt21FQUABBEGAwGJCYmIi6ujqMGzfOYz+j0Qij0ehebmpqGmr8PcQmJyPBbIb54EHExWVg/35Nn5+j1+v9EstgBFMsQHDFw1i8C6Z4wiGW5ORkP0QTviwWgVUIREQK4tw0RBRIfdb6Z2RkoL6+Ho2NjbDb7aiqqkJWVpbHPnq9HjU1NQCA5uZm1NXVITEx0T8R98Hd5vHwYQ5nICIKAKuVbcWIiJTkmpuG52IiCoQ+KxHUajUKCwuxevVqSJKEnJwcpKWloaKiAgCQl5eH2bNnY+PGjSgqKgIAzJ07F/Hx8f6N3Itz2zzqdBKam1WQJEChKRqIiMKexSIgIYFPv4iIlOKqRGBVGBEFQp9JBADIzMxEZmamx7q8vDz3a51Oh5KSEt9GNkiOtDTIGo0ziTBSgiQJaGkRoNUyM0tEwW/37t0oLy+HJEnIzc1FQUGBx/b29naUlpbCZDLB4XBg1qxZyMnJQVNTE1588UU0NzdDEAQYjUbcfPPNAYnZYmElAhGRklxzIrBLDhEFQr+SCCFFo4F99GhojhyB9lJnNtZsVkGrdSgcGBHRhUmShLKyMpSUlEAURSxZsgRZWVlITU1177Nt2zakpqaiuLgYFosFDz30EKZNmwa1Wo277roL6enp6OjoQHFxMSZNmuRxrL9YrQIMBp5jiYiU4uqSwzkRiCgQwrLI39WJMx73AAAgAElEQVTmUadznkhPnw7Lr0lEYaa2thYGgwFJSUnQaDTIzs5GdXW1xz6CIMBms0GWZdhsNsTFxUGlUkGr1SL9zHCu6OhopKSk9GjH6y9WK9uKEREpiZUIRBRIYXl37UhPh+boUehG2AGAkysSUUgwm80QRdG9LIpij0TA9OnTcfLkSSxYsABFRUWYN28eVOdN+tLY2IijR4/26JDjL87uDLxwJSJSiqsSgXMiEFEghN9wBjgnVxQ6O2Ho+ieAJFYiEFFIkOWeN+KCIHgs79mzB6NHj8aKFSvQ0NCAlStXYsKECYiJiQEA2Gw2rFu3Dnfffbd73fkqKytRWVkJAFizZg30ev2gY7bbgfZ2FQyGKOj1EYN+H41GM6Q4fC2Y4mEs3gVTPIzFu2CLJxxZrSpERcmIGPxpmIio38I2iQAAI0/XAvgxkwhEFBJEUYTJZHIvm0wmaLVaj322b9+OgoICCIIAg8GAxMRE1NXVYdy4cbDb7Vi3bh2mTZuGKVOmeP0co9EIo9HoXm5qahp0zGazAOASaDRtaGpqG/T76PX6IcXha8EUD2PxLpjiYSzeDSae5ORkP0UTnpwVYaxCIKLACMu7a3tGBgAgru4IIiJkDmcgopCQkZGB+vp6NDY2wm63o6qqCllZWR776PV61NTUAACam5tRV1eHxMREyLKMTZs2ISUlBTNnzgxYzGwrRkSkPHbJIaJACstKBGnkSEhxcdAcPQKtVmISgYhCglqtRmFhIVavXg1JkpCTk4O0tDRUVFQAcLbWnT17NjZu3IiioiIAwNy5cxEfH4/9+/djx44dGDVqFB577DEAwB133NGjPa+vcTIvIiLlWa0CJ7glooAJyyQCBAH29HRoDh+GTsckAhGFjszMzB43/nl5ee7XOp0OJSUlPY6bMGEC3nzzTb/Hdz5O5kVEpDxWIhBRIIXt3bWrzaNWK3FOBCIiP3ENZ2AlAhGRcqxWzolARIETtnfX9vR0qE+cQGJ8OysRiIj8xGJxDWfgxSsRkVKsVhXPw0QUMOE5nAGAIz0dgixjwrBa7DD7d0wwEdHFyjWcgZUIRBQudu/ejfLyckiShNzcXBQUFHhsb29vR2lpKUwmExwOB2bNmoWcnJx+HesvFovA8zARBUzYPqJ3tXkcLx1Ec7MKEpOzREQ+56pEYBktEYUDSZJQVlaGpUuXYsOGDdi5cydOnDjhsc+2bduQmpqKtWvX4oknnsDmzZtht9v7daw/2O1AezsrEYgocMI+iTDKdgiSJKClRVA4IiKi8GO1qhAVJWHYMKUjISIautraWhgMBiQlJUGj0SA7OxvV1dUe+wiCAJvNBlmWYbPZEBcXB5VK1a9j/cHVJYcTKxJRoIRtEkGOi4MjKQnJrYcAgPMiEBH5gbOtGC9ciSg8mM1miKLoXhZFEWaz2WOf6dOn4+TJk1iwYAGKioowb948qFSqfh3rD64JblkRRkSBErZzIgDOaoSRTbUAcKZDg0PZgIiIwoyzrRgvXIkoPMhyz6SoIHhWs+7ZswejR4/GihUr0NDQgJUrV2LChAn9OtalsrISlZWVAIA1a9ZAr9cPOuaTJ52fkZoaB70+dtDvAwAajWZIsfgSY/EumOJhLN4FUzy+jiXskwjx328DwEoEIiJ/YCUCEYUTURRhMpncyyaTCVqt1mOf7du3o6CgAIIgwGAwIDExEXV1df061sVoNMJoNLqXm5qaBh3zsWMRAPSQ5RY0NXUN+n0AQK/XDykWX2Is3gVTPIzFu2CKZ7CxJCcn97o+rO+s7enpiLSYoIX5TCUCERH5ksXCybyIKHxkZGSgvr4ejY2NsNvtqKqqQlZWlsc+er0eNTU1AIDm5mbU1dUhMTGxX8f6g2s4AxO6RBQoYV+JAADjcQinT09QOBoiovBjsQhISeGFKxGFB7VajcLCQqxevRqSJCEnJwdpaWmoqKgAAOTl5WH27NnYuHEjioqKAABz585FfHw8APR6rL+xSw4RBdpFkUS4OuYH7Nv3I4WjISIKP1YrKxGIKLxkZmYiMzPTY11eXp77tU6nQ0lJSb+P9TdWIhBRoIV1jb9j9GjIajVuGrMPf/1rFDo6lI6IiCi8WCwC24oRESmIlQhEFGhhnUTAsGFwjBqFfxt+AK2tKmzfHqV0REREYaOrC7DZ2J2BiEhJVqsKUVESIiKUjoSILhbhnUSAc0iDwVoLvd6B99+PVjocIqKw4SqhTUhgJQIRkVLYJYeIAu2iSCJojhzBrFvaUVkZhdbW3vv1EhHRwLCElohIeRYLK8KIKLDCP4mQkQGVzYbbrj0Cm01ARQWHNBAR+QIn8yIiUh4rEYgo0PrVnWH37t0oLy+HJEnIzc1FQUFBj32+//57vPrqq3A4HBg+fDiefPJJnwc7GK4ODZlx+5GcPBHvvx+NX/yCMywSEQ0VKxGIiJTHSgQiCrQ+kwiSJKGsrAwlJSUQRRFLlixBVlYWUlNT3fu0tbXhlVdewbJly6DX69HS0uLXoAfClUQYduQw8vNtKCuLxenTArRaZmyJiIbibCUCL16JiJRisQi45BJe1xJR4PQ5nKG2thYGgwFJSUnQaDTIzs5GdXW1xz5/+9vfMGXKFOj1egBAQkKCf6IdBMlggD05GTF//jMKZrWiu1vAxx9zgkUioqE6W4nAi1ciIqVYrSomc4kooPpMIpjNZoii6F4WRRFms9ljn/r6erS2tuKJJ57A4sWL8fnnn/s+0sESBFiWL0dETQ2mfPsnjB1rZ5cGIiIfsFhYiUBEpDSLRWAyl4gCqs/hDLLc86QkCJ4dDhwOB44ePYrly5ejq6sLJSUlGD9+PJKTkz32q6ysRGVlJQBgzZo17soFv5s3D9JbbyFh7bOYf/c8LP+9AXa7HgaDc7NGowlcLH0IpliA4IqHsXgXTPEwlouH1cpKBCIiJXV3Ax0drEQgosDqM4kgiiJMJpN72WQyQavV9thn+PDhiIqKQlRUFC6//HIcO3asRxLBaDTCaDS6l5uamoYaf7+pH38ciUYjCvc/gmXSn7F5cwcKC9sAAHq9PqCxXEgwxQIEVzyMxbtgiiccYjn/3EW9s1hUiImRoOnXFL1ERORrrmQuuzMQUSD1OZwhIyMD9fX1aGxshN1uR1VVFbKysjz2ycrKwv79++FwONDZ2Yna2lqkpKT4LejBcIwbh9YFC2D46xuYO/p/OaSBiGiI2FaMiEhZrglu2Z2BiAKpz+dHarUahYWFWL16NSRJQk5ODtLS0lBRUQEAyMvLQ2pqKq666io8+uijUKlUuOGGGzBq1Ci/Bz9QrQ89hOj33sPa9geQ9vVunDihRmqqQ+mwiIhCEtuKEREpi5UIRKSEfhWhZmZmIjMz02NdXl6ex3J+fj7y8/N9F5kfyDExsDz5JC6ZPx8P4A/YurUQCxe2Kh0WEVFIslpVnA+BiEhBrglumdAlokDqczhDuLFNnw7bDTdglWoFdr59WulwiIhClsUiICGBF65EREpxDWdgJQIRBdJFl0SAIKDlqacQJXRh/oGlqK1VKx0REVFIcg5n4IUrEZFSLBZXlxwmdIkocC7KObUdY8fiVOH9mPvyevzxD3dg6tS8vg8iIgqA3bt3o7y8HJIkITc3FwUFBR7b29vbUVpaCpPJBIfDgVmzZiEnJ6dfx/qa1SrwwpWISEGu4QysRCCiQLr4KhHOkBcvxMnIMbhxy2OQu7qVDoeICJIkoaysDEuXLsWGDRuwc+dOnDhxwmOfbdu2ITU1FWvXrsUTTzyBzZs3w2639+tYX7NaVbxwJSJSECsRiEgJF20SAdHR+PL2pzGuez8al/5e6WiIiFBbWwuDwYCkpCRoNBpkZ2ejurraYx9BEGCz2SDLMmw2G+Li4qBSqfp1rC/ZbEBnJysRiIiUZLWqEBUlYdgwpSMhoovJxZtEADDh0euxVchH4qZVUNXVKR0OEV3kzGYzRFF0L4uiCLPZ7LHP9OnTcfLkSSxYsABFRUWYN28eVCpVv471JddkXpxYkYhIOVarwIowIgq4i3JOBBedTsLTU59B3ldXI/7JJ9H80ktKh0REFzFZ7nkhKAiCx/KePXswevRorFixAg0NDVi5ciUmTJjQr2NdKisrUVlZCQBYs2YN9Hr9gGN15SeSk+Og18cM+PjzaTSaQcXhL8EUD2PxLpjiYSzeBVs84cRiUSE+nslcIgqsizqJAAA/uS0Jq75chlUfLEfH55+j87rrlA6JiC5SoijCZDK5l00mE7Rarcc+27dvR0FBAQRBgMFgQGJiIurq6vp1rIvRaITRaHQvNzU1DTjWf/5zGICRAFrQ1NQ54OPPp9frBxWHvwRTPIzFu2CKh7F4N5h4kpOT/RRNeHFOcMtKBCIKrIs+iTB9ug0/iSjCg1GvQly2DI2ffgpERiodFhFdhDIyMlBfX4/GxkbodDpUVVVh0aJFHvvo9XrU1NTg8ssvR3NzM+rq6pCYmIjY2Ng+j/Ul12ReLKMlonDTV6ebrVu34osvvgDgnBD3xIkTKCsrQ1xcHD744AN89tlnEAQBaWlpWLhwISIiIvwWKysRiEgJF30SYfhwGTfcHImHtr+APx+dibiXXkKrHy+8iYi8UavVKCwsxOrVqyFJEnJycpCWloaKigoAQF5eHmbPno2NGzeiqKgIADB37lzEx8cDQK/H+otrTgROrEhE4cTV6aakpASiKGLJkiXIyspCamqqe5/8/Hzk5+cDAL7++mt8+OGHiIuLg9lsxscff4wNGzYgIiIC69evR1VVFa6//nq/xWu1CkhJYTKXiALrok8iAMCcOQ7cueUWPPeTW5D8wgvo+PnP4fDjxTcRkTeZmZnIzMz0WJeXl+d+rdPpUFJS0u9j/cVqZSUCEYWfczvdAHB3ujk3iXCunTt34pprrnEvS5KErq4uqNVqdHV1eR1W5ivOVrtM5hJRYF3U3RlcZsyQERsr4dnkdYAgIP6JJ5QOiYgoqLW0OH998OKViMLJQDrddHZ2Yvfu3Zg6dSoAZ5J31qxZuO+++3DPPfcgJiYGkydP9mu8FgvnRCCiwGMlAoCYGOCmm2z4r8/G44lFj0D3zO/Q/umn6MzNVTo0IqKg5BrOEBfHi1ciCh8D6XTz97//HZdddhni4uIAAK2traiursaLL76ImJgYrF+/Hjt27MDPfvazHsf6oktOdzfQ0aGCwRAFvd438y4EUycNxuJdMMXDWLwLpnh8HQuTCGfk53fg3Xdj8NGlD+C2cW8iYflyNGZnA9HRSodGRBR0LBYBcXES1GqlIyEi8p2BdLrZuXMnrr32WvdyTU0NEhMT3fPUTJkyBQcPHuw1ieCLLjlmswqAAWp1G5qa2gZ8fG+CqbMHY/EumOJhLN4FUzyDjcVbpxwOZzjjuus6MWKEhPc+TEDLqlXQHDuGuD/+UemwiIiCktWqYgktEYWdc7vk2O12VFVVISsrq8d+7e3t2Ldvn8c2vV6PQ4cOobOzE7Iso6amBikpKX6L1dUlhxPcElGgsRLhjIgI4OabO/D++9FoeXYaYvPzMfwPf0DHL34Bx5gxSodHRBRUrFaB8yEQUdjpT5ccANi1axcmT56MqKgo97Hjx4/H1KlTsXjxYqjVaowZM8aj2sDXXMPKOMEtEQUakwjnyM/vwP/8Tyw+/TQK+StWIPLTTyHOmQPLsmWw5ecDXsbEERFdbCwWViIQUXjqq0sOAFx//fW9tm6cM2cO5syZ48/w3FyVCEzoElGgcTjDObKzuzBypAPvvx8N6ZJLYHrtNcgJCdAtXAjxF7/AsO++UzpEIqKgYLGwEoGISElnKxF4LiaiwGIS4RxqNTBrVgc++ywKVquA7h//GKe2bUPzs89Cc/gw9DffjBGPPAJVQ4PSoRIRKYq9yYmIlHV2TgRWhRFRYDGJcJ78/A7YbAIqKs6McVOr0T53Lhr/9je03Xsvot97D4nXXou40lLAZlM2WCIihbA3ORGRslyVCJxYkYgCjUmE82RldSM11Y4tWzxbO8rx8bCUlKBx+3Z0TpuG+GeeQeL11yPqgw+AXnoKExGFK1lmJQIRkdJYiUBESmES4TyC4KxG2LEjEmZzz4kUHWPH4vSf/oSmP/8ZclwcdAsWQPzlL6HZu1eBaImIAs9mA7q7WYlARKQkq1WF6GgJw4YpHQkRXWyYROjFrbd2wG4X8PHH0V736Zo2zTlfwpo10Bw8iJHTpyPh0UehOnUqgJESEQWexcISWiIipTknuGUyl4gCjy0eezFxoh0ZGd3YsiUac+e2e99Ro0H7XXehIz8fw59/HrF/+hOi//IXtC5ahNb584HIyMAFTUQUIK5xuAkJvHilgZFlGTabDZIkQfBB2+SGhgZ0dnb6ILKhYyzeeYtHlmWoVCpERUX55N/DxcbZapfJXFKWLMvo6Ojw2Xl9KELl3KeEC8UymHMxkwi9EATg1ltt2LAhDg0NKiQlXfgELSckwPL442j71a+QsHIl4n/3O8T9/vfo+vGP0TV1KjqnTkX3pElgvRkRhYOz43B58UoDY7PZMGzYMGg0vrn80Gg0UKvVPnmvoWIs3l0oHrvdDpvNhuho79Wf1DurlcPKSHlms9mn5/WhCKVzX6D1FctAz8X9Gs6we/duPPTQQ3jwwQexZcsWr/vV1tbitttuw1dffdWvDw9mt97aAVkW8N57/f+l5sjIgPnVV9H0xhvoyM+H+p//RPzvfoeR+fkwXH45xNtvR9zzzyPiq6/Y2YGIQtbZ3uS8eKWBkSQpKC40KXhoNBpIEhOSg2G1qpCQwL87Upbdbud5PQwM9Fzc539xSZJQVlaGkpISiKKIJUuWICsrC6mpqT32e+2113DVVVcNPOogNG6cHVOnduLpp+MREyPjP/7jAsMaztN17bXouvZaAIDq1ClE/N//IeKrrxD51VeIX7sWACBHRqIrMxNdU6Y4KxWysiAzC09EIYCVCDRYSpe6UnDiv4vBsVgEpKYymUtEvjGQc3GfSYTa2loYDAYkJSUBALKzs1FdXd0jifDxxx9jypQpOHz48ADDDV7l5Wbcf78WS5aMwP79w/Dkky0DHpEgjRwJ28yZsM2cCQAQTp9G5K5diPjqK0R89RXiSksx/PnnIWs06J48GersbMSOHAlHairsKSlwpKZCTkhwjrEgIgoCrESgUGU2m3HbbbcBAE6dOgW1Wg2dTgcA+PDDDxEREeH12D179uDtt9/GypUrL/gZ+fn52Lp1q++CJvKCrXaJQu+8vnDhQhw8eBBz5sxBRUUFli9fjsmTJ/fr2L1796KhoQG5ubk+iWUo+kwimM1miKLoXhZFEYcOHeqxz65du/D444/jj3/8o9f3qqysRGVlJQBgzZo10Ov1g43bpzQaTa+x6PXABx8Ay5Y5sGFDLI4di8brr9tx5t/l4Oj1wPjxwNy5AIDulhYIX34J1RdfQPPFFxBeeQUJHR0eh8jDh0MePRoYNQqy62fMGPcyEhP9lmTw9nejBMbiXTDFw1jCHysRKFTpdDp88sknAIB169YhNjYW9957r3v7hcpyJ0+e3K8LvVBMIDgcjqAZt0v9Z7FwTgSic8/rGzZsQHR0dNCe1xsbG/H1119j165dAICKiooBHf/999/ju+++C40kgiz3PDmdX+rw6quvYu7cuVCpLjzFgtFohNFodC83NTX1N06/0uv1F4zl0UeBUaOisXjxCPz0pyq8+qoZ48fbfRdAVpbz55FHoBdFmA8ehPrECaiPH3f+efIk1CdOQPOPf0C9cyfULS0eh8tRUXAYDJDi4yHHxzv/HD4c0vDhkBISnK9d61z7DB/u/hMXyND19XcTSIzFu2CKJxxiSU5O9kM04cNiUUEQZMTF8eKVQt/DDz+MESNGYO/evfjRj36E/Px8PP7447DZbIiKisL69esxbtw4VFVVYdOmTdi8eTPWrVuHkydP4p///CdOnjyJ+fPnY8GCBQCA8ePH49ChQ6iqqsL69euh1Wpx4MABTJo0Cb///e8hCAI+/fRTPPnkk9DpdPjRj36EY8eOYfPmzR5xHT9+HIsWLUJ7u3M45apVq/DjH/8YALBx40a88847EAQBN9xwA5YuXYqjR4+iuLgYJpMJGo0GmzZtQl1dnTtmAFi2bBkmTZqE2267DVOmTMHtt9+Ozz//HPPmzUNraytee+01dHV1YezYsSgtLUV0dDROnTqF4uJiHDt2DADw9NNPY/v27dDpdJg/fz4A54OhkSNH4je/+U1A/psR0N0N2GzszkDUG1+d113ntMGe1//nf/7HI64777wTJpMJN954I1atWgUAeOedd7B8+XK0trZi3bp1uPrqq9He3o6SkhLs378fdrsdRUVFyMnJwXPPPQebzYZdu3bhgQcewKhRo3r9XoHQZxJBFEWYTCb3sslkglar9djn8OHDeOGFFwAAFosF3377LVQqFX7yk5/4OFzlzJnTgfR0O+bP12HWLD02bjyNG27wQ8sOQYAkipBEEd1eMmOCxeJMLpxJMGhOnIDqX/+CymKBymKB5tQpqCwWCBYLVG1tfX6krNFAjo7u+RMVBU1CArRqda/b5IgIQKOBrNEAERHOP4cN63152DDIrtcaDaBWQ1arAbXa+R4qVY/1525HHwkqIgoc14zg/N+ShmLFinjs2ze0rkWCIHg87Ljiim489ZRlwO9z5MgRvPHGG1Cr1bBarXj33Xeh0WiwY8cOPPPMM3j55Zd7HFNbW4u33noLbW1tmDZtGgoLC3s8ZNm7dy8+++wzGAwG3HrrraiursakSZOwePFivPvuuxg1ahQWLlzYa0x6vR6vv/46oqKicOTIEdx///34+OOP8dlnn2Hbtm344IMPEB0djdOnTwMAHnzwQdx///2YMWMG7HY7uru7UVdXd8HvHRkZ6Z4w22w2Y+6ZKslnnnkGr7/+OgoLC7F8+XJMnToVZWVlcDgcaGtrg8FgwPz58zF//nxIkoStW7figw8+GPDfOw0eh5VRMPLFef18Sp7X/+M//gPDzhvLPpTzenl5OX7961+7KycAoKOjA1u3bsVXX32FoqIifPbZZ3jhhRdwzTXXYP369WhpacEtt9yCadOm4dFHH8V3332H1atXA0C/v5c/9JlEyMjIQH19PRobG6HT6VBVVYVFixZ57PPiiy96vP63f/u3sEoguGRldePDD5swb54Ov/61DsuWWbBgQVvApyuQ4+Nhv+IK2K+4ou+dHQ4IVuvZpILV6lxuaXG+tlgg2GwQOjrO/pyzjFOnoLFaPbe3t0PopULF32S1GpeoVM4EgyA4EwwqFaBSOZMQfS27fgSh73VnlntbJ6tU0ERFQWu3ez9OEABBcK53rQM8tsvn7Of+cX9ZuffXXtapo6IQ7+r40ds/yHPX9fb6vBjkc+Pp7U9vrwGoYmMRd+6QnN727U1f/yOd91lyP+JTiSLwi19c+H1pwNibnMLNzJkz3eX8FosFDz/8MI4ePQpBENDd3d3rMbm5uYiMjERkZCT0ej1OnTqFxMREj32uuuoqd2XTxIkTcfz4ccTExGD06NEYNWoUAKCgoAD//d//3eP9u7u7sWzZMuzbtw8qlQpHjhwBAHzxxRe47bbb3G24tFotWltbUV9fjxkzZgAAoqKi+jVben5+vvv1gQMH8Oyzz8JisaCtrQ3XXXcdAGDnzp3uB0VqtRrx8fGIj4+HVqvF3r17cerUKUycONE9BpkCg8PKiC7MV+f186tTh3Je782tt94KAJg6dSqsVitaWlqwY8cOfPLJJ9i0aRMAoLOzEydPnuxxbH+/lz/0+RtGrVajsLAQq1evhiRJyMnJQVpamnsMR15ent+DDCYpKQ5s2dKEhx4agZUrE3DgwDCsWdOMyEilI/NCrYY8YgQcI0YM6vBey8FlGejqgtDdDXR3Q7Dbnct2+9llux3C+etcy3Y7IEnO1w6Hx2vB4XCuc70+Z9+YqCi0t7Y6l88c5/rpc9n1Wpa9rhPO2d/9HWXZuf7841QqaLq7e38vh8P5pyw7ky2uH9d21+f1tq0/N/u9bBcEATGu9zr3v9O5f3p7fW4cAIQLbDv/tbdkUnyvawNPHjGCSQQ/sFoFPv2iIRvMk6XzaTQa2O1DH14YExPjfr127VpkZ2ejrKwMx48fxy9/+ctej4k85xe/Wq3uNY5zJ/Tyto83L7/8MkaOHIlPPvkEkiQhPT0dgHOY6fkVD70NPQWcfz/nbuvs9KygPPd7P/LIIygrK8PEiRPxxhtv4Msvv7xgfHfccQfefPNNNDY24vbbb+/39yLfsFhYiUDBxxfndV/xxXnd4XD02Gco5/XenH8+d1XY/ed//mePoQnffPONx3J/v5c/9KupZ2ZmJjIzMz3WeUse3H///UOPKsjFxMh46aXT2LDBjvXrh+PIEQ1eecWMkSMvkmywIACRkZDP/I8WqF9fkXo9rCE+1t5fgiYeWYZeFJ2xeEs+eDmur/cdTJJDFEVnUod8ipUIFM6sVisMBgMA4M033/T5+2dkZODYsWM4fvw40tLSvE7YZbFYcMkll0ClUuGtt95yX8xed9112LBhA37+85+7hzNotVpccskl2LZtG6ZPn47Ozk50dXUhJSUFBw8eRGdnJzo7O/G3v/3NPa/C+VpbW5GUlITu7m6899577r+Da6+9Fps3b8Zvf/tbOBwOtLe3Y/jw4ZgxYwaee+452O12j4pUCgxWIhD1X7Cc13uzdetWXHPNNdi1a5e70uu6665DeXk5Vq1aBUEQsHfvXlx55ZWIi4tDa2trwL7XhXBE6yCpVEBRkRWbNpmxd68GN9+sx969/crJEIWvc4aBuOezODMnBiIivP9ERl74JyoKiI4GXHNyxMQ4f2JjIcfFOTuYnJksVE5IcP6MGAGcN38L+YYzicCnXxSe7rvvPjz99NO49dZbe30KNVTR0dH43e9+h7lz56KgoAB6vR7x8T3rt37961/j7f7t3PoAAB08SURBVLffxsyZM3HkyBH3U7WcnBzk5eVhxowZuPHGG93lrqWlpSgrK4PRaMTMmTPR2NiIlJQUzJo1C0ajEQ888ACuvPJKr3E99thjmDlzJu644w6Pp19PPfUUqqqqkJubi+nTp+PAgQMAnE/jsrOzMWvWLHZ2UMDZORGYRCDqS7Cc13szYsQI5Ofno7i4GM899xwA58SQ3d3dMBqNuOGGG/Dss88CALKzs3Ho0CHceOONeP/99/3+vS5EkL3VwAVAXxP+BMpQn+LW1AzDvHk6NDcLKC1txs032xSLxdeCKR7G4l0wxRMOsVxs3RkGei7+6U8TkZXVhd//vtlnMQTTvxsguOIJp1ja29s9SkyHylfDGXxhILG0tbUhNjYWsixj6dKlGDt2LO655x5FYhksSZJw00034aWXXnIPtRhsPL39u+B5+MLeeCMa/+//afHllw0YNcp3Nw/hdL7xpWCKBQiueIKpRaySvxN6O68vXLgwpH5HDeRczEoEH/jRj7rx0UencPnldvz2tzps2BDXZ3U2EVGoYiUC0dC89tpruPHGG5GTkwOr1Yq77rpL6ZAG5ODBg7jmmmtw7bXX9plAIP9wVSJwOANRcAj18/pAsf7eRxITJbz1VhMWLx6B556Lx86dkZg9uwM33WSDTscTPBH1z+7du1FeXg5JkpCbm4uCggKP7Vu3bsUXX3wBwPkk8MSJEygrK0NcXBw++OADfPbZZxAEAWlpaVi4cKHHBEC+IMuuFo88rxEN1j333OPTyoNAu/TSS/uceJH8y2p1zYnAhC5RMAj18/pAMYngQ1FRwPPPN2Py5G688kosHn10BBYvlpGd3YVbbunAjBk26PW88Cai3kmShLKyMpSUlEAURSxZsgRZWVlITU1175Ofn+9uy/b111/jww8/RFxcHMxmMz7++GNs2LABERERWL9+PaqqqnD99df7NMaODgEOB7szEBEpyWJRISZGQj86eRIR+RxPPT4mCEBhYRvmzWvD999r8MEH0fjgg2gUF4/A0qUypkzpwsyZHZg+3QaDgQkFIjqrtrYWBoMBSUlJAJwT6FRXV3skEc61c+dOXHPNNe5lSZLQ1dUFtVqNrq4uaP0wsSRnBCeicDeUirC2tjZs2rQJx48fhyAIuO+++3DppZf6PEa22iUiJTGJ4CeCAFx5pR1XXmnF4sVW7N+vwYcfRuPDD6OwbNkIlJTI+PGPu3DLLTbMmNGBlBRekBNd7Mxms7Mt5RmiKOLQoUO97tvZ2Yndu3fjN7/5DQBAp9Nh1qxZuO+++xAREYHJkydj8uTJPo/R1Zs8IYHnLCIKP0OpCAOA8vJyXHXVVSgqKoLdbkdnZ6df4mSrXSJSEpMIASAIwOWX23H55VY8+qgVBw9q8OGHUfjww2g8/ngCHn88AZmZziEPs2c7u9KxPI3o4tNbsxxBEHrd9+9//zsuu+wy94Vra2srqqur8eKLLyImJgbr16/Hjh078LOf/azHsZWVlaisrAQArFmzBnq9vt8x1tY640lJGQ69Pq7fx/VFo9EMKA5/C6Z4wimWhoYGaHz8C87X7zcUjMW7C8UTGRkZNP/Gh1IR1t7ejh9++AH3338/AOd39td/B+fcNKxEICJlBNdvmIvEpZfacemlrXjkkVYcPqzGRx85KxRWrkzAypXAsGGXYMwYO8aNsyMjw47x48++5i8MovAliiJMJpN72WQyeR2SsHPnTlx77bXu5ZqaGiQmJrr7Ek+ZMgUHDx7sNYlgNBphNBrdywNpE3X8eCQAEbLcjKam7n4f15dgalcFBFc84RRLZ2enT1uBDbSd1y9/+Us88MADHnOFvPzyyzhy5Aiefvppr8csX74ckydPxl133YU//OEPSEhI8Nhn3bp1GD58+AUn1dq2bRvS09Pdpe1r167FlClTev1/dKiCqfUl0Hc8nZ2dPf5dKdXicSgVYY2NjYiPj8fGjRtx7NgxpKen4+6770ZUVFSPY4eSzAWA9nYNRBE+T76EU9LSl4IpFiC44mlsbFQ0afnzn/8cixYtQk5ODgDn381LL72EI0eO4JlnnvF6zOOPP46rrroKd955J/74xz/2OK+vXbsWsbGxWLhwodfP/uijj5CRkYHLLrsMAPDMM89g6tSpuO6669z7DPbvZsGCBThw4ABuv/12/PWvf3XH2x979+7Fv/71L49rvf7EMpCELpMICsvIcODBB1vx4IOt+Mc/1PjhBxG7d3egtlaDQ4c0+OSTKNjtZ59EGgwOZGQ4kwrjx3e7X19yiQQvDyyJKERkZGSgvr4ejY2N0Ol0qKqqwqJFi3rs197ejn379uHBBx90r9Pr9Th06BA6OzsRERGBmpoaZGRk+DxG15wIHItLoejWW2/F+++/75FEeP/997F8+fJ+Hf9f//Vfg/7sbdu2wWg0upMIjz322KDfSynB1A/eX4ZSEeZwOHD06FEUFhZi/PjxKC8vx5YtW3D77bf3OHYoyVwAMJsTcckl3WhqOj2g4/oSTklLXwqmWIDgikeWZUWTlvn5+Xj33Xcxbdo0d8Lyvffew/Lly73GJcsyHA4H7HY7Nm/eDAA99pUkCZIkXfC7ffTRRzAaje7rraKiIo/3GmxCt7GxEdXV1di1axcA5+8PV7z9sWfPHnz33Xcev+v6E8tAErpMIgSRMWMcyMqSMGOG1b2uuxs4dkyD2lrPn3ffjYbVGuveLypKhig6oNdLEEXnj14vQa93QKdzvXau1+kciI5W4hsS0YWo1WoUFhZi9erVkCQJOTk5SEtLQ0VFBQAgLy8PALBr1y5MnjzZ4+nW+PHjMXXqVCxevBhqtRpjxozpkYH2BfYmp1B2yy234Nlnn0VnZyciIyNx/PhxNDQ04Cc/+QmKi4uxZ88e2Gw23HLLLXj00Ud7HD9lyhR8/PHH0Ol0eOGFF/D2228jOTkZoii6nxC99tpreO2119DV1YWxY8eitLQUe/fuxSeffIKvvvoKL7zwAl5++WU8//zzMBqNmDlzJr744gusXLkSDocDkydPxtNPP43IyEhMmTIF//7v/45PPvkEdrsdL730EsaNG+cR0/Hjx7Fo0SK0t7cDAFatWoWf/vSnAICNGzfinXfegSAIuOGGG7B06VIcPXoUxcXFMJlMUKvVeOmll1BXV4dNmza5L6aXLVuGSZMm4bbbbsOUKVNw++234/PPP8e8efPQ2tra4/tFR0fj1KlTKC4uxrFjxwAATz/9NLZv3w6dTod7770XgPOJ+8iRI91P7oPRUCrCRFGEKIoYP348AGDq1KnYsmWLX+J0TqzI8zDRued1jUbj0/P6pEmTAAz+vL5q1SrY7fYBn9fvvPNOmEwm3HjjjVi1ahUA4J133sHy5cvR2tqKdevW4eqrr0Z7eztKSkqwf/9+2O12FBUVIScnB8899xxsNht27dqFBx54AKNGjcITTzyBjo4OREVFYf369T0+c6CYRAhyw4YB48Y5qw3OJctAY6PKnVQ4dkyDpiYVzGYVTp1SYf9+DUwmNTo7e8+ex8Y6kwo6nYS4OBlxcRJiY2XExp59HRcnIylJBVmOOrOPjJgYyf06KkpGZKTM+RuIfCgzMxOZmZke61zJA5frr7++19aNc+bMwZw5c/wZnntiRVYi0FDFr1iBYfv2Dek9BEHweHLcfcUVsDz1lNf9dTodrrrqKvzv//4vbrrpJrz//vvIz8+HIAhYvHgxtFotHA4HbrvtNuzbtw9XXHFFr+/z3XffYevWraioqIDdbsf06dPdSYQZM2Zg7ty5AJylra+//joKCwtx4403ui8uz2Wz2fDII4/gjTfeQEZGBhYtWoTNmzfjt7/9rTvm/9/encdEcb5xAP/OLHLJtRxyeBWvNh5tYiBaV0q0SKBqpcba2ERtGmIrWCNWa03TW6NVkZ+mKGoJVdPUI5ZgbaqS2kprbbWgFbEVRZvaoiKgnHLs7vz+2O7IujvLIrvsKN9PsmFn3nd2n31n5mF5ed+ZI0eO4PPPP0dOTg42bNhgsX1oaCi+/PJLeHt748qVK0hPT0dhYSGOHTuGw4cP49ChQ/Dx8cHt26b/WL/xxhtIT09HcnIyWlpaIEkSKisr7bazl5eX/MdwbW2tzc/37rvvYvz48cjNzYXBYEBTUxMiIiKQmpqK119/HUajEQcPHsShQ4fsvpe7dWdEWFBQEEJCQlBZWYmoqCiUlpYqXkuhuxoaROZhUh1n5PX7dSWvT5061al53dyJ8KB5/cCBAxg8eHCX83peXh7mz5+PwsJCed3du3dx8OBB/PLLL3jzzTdx7NgxbNq0CTqdDhs3bkRdXR2mTp2KuLg4LFu2DOfOncPq1asBAA0NDSgoKAAAFBUV4ZNPPsGOHTu6shus8M+/h5QgAOHhRoSHt0Gna7NZR5KAxkYBNTWi3MFQXa2Rl2tqTOsaG0XcuuWBxkYBjY0impsFtLV17HwIthuLRnOvQ8HLyzQq4t6yZZl5nYcH0KePBE9P03NPTwl9+gAeHhI8PU1lpgfkn8HBApqbvaDRmLbx8ID8XGldnz6ARgOIogSNxtZzJ+4Uol6gvl6AKJo6HIkeRikpKSgoKJA7ETZu3AgA+Prrr/HFF1/AYDDg5s2buHTpkuKXzV9//RVJSUnw+W9Y35QpU+SyixcvYt26daivr0dTU5PF3FhbKioqMGjQIHk47IsvvoidO3fKXzaTk5MBAE8++SS+/fZbq+3b29vxzjvv4MKFCxBFEVeuXAEA/Pjjj3jppZfkGLVaLRobG3H9+nX5NW3N1bfFfCcCe5/vxIkT2LRpEwDTqKqAgAAEBARAq9WitLQUN27cwKhRoxAcbP87hbt1Z0QYALz66qvYvHkz9Ho9+vXrZ3c+9YNqawNaWgSOCCP6jzmvmzsR1JTX9Xp9l/O6LTNmzABgGuHU0NCAuro6FBUVobCwEDk5OQBM0xH+/fdfq23r6+uRkZGBK1euQBAEtLd3/5pW7ER4hAkC4O8vwd/fgMceM3Rp27Y2UweEp2cI/vnnDhobBTQ1if91NAhobhbQ2irg7l3Tz3sP0y8283JLi6ljorr6XpleL6CtDWhvF9DebvppMDh6QYeQzqt0kYeHZLejQRDuLYuiadnTUwNJCoMoosND6lDftGwus7Xu/mWgY11J3sZyPSAIkrxsfvj4aNDWFiiXAR3rW76mvYcoSvK2SuXmqaFKdfz8RDQ3+yrWsVxv+XqdbyN1oS4QEiIgJsbph0yvZv7vF6/BQt1l7z9LjnqQ+aZJSUn48MMPUVpaipaWFowZMwZ///03tm3bhm+++QZBQUFYsmQJWlpa7L6O0jz5jIwM5ObmYtSoUdi7dy9Onjxp93VszcHvyMvLC4Dpj1uDwfp3+Y4dOxAWFobCwkIYjUYMGTJEft37Y1R6Lw8PD4uy+29L6OvrKz/v6uebM2cO9uzZg5s3b9q8NoAadWdE2GOPPYa1a9e6Mjx5WhmnM5DaOCOvPwhzXj937twjkdcdic08Em/79u1WUxNKSkosltevXw+dTofPPvsM165dw6xZsxx6T3vYiUA2eXoCwcESQkMBPz/XXyzFaITcodDWBuj1gsXztjbA31+L6uo70OsF6PWAXg8YDMJ9P9Gh3NRJYTQKMBhMZZbP721nft5xvcFgGs1hXjYaIT/69PHC3bt6i3UGgwBJQoftTNuY15liES226VjH8qdpvbltLMsFq/WCIEKvN/Wcdqzb8Tkg2FwvSa74azDIBa/ZdUFBEsrK3B3Fo6W+nv/9oodb37598fTTT2Pp0qVISUkBYBrq6ePjg4CAANy6dQvff/+9fF0BW8aPH4+MjAykp6fDYDCgsLAQ8+fPB2C63Wp4eDja29uRn5+PiIgIAICfnx+ampqsXmvYsGG4du0arl69iujoaBw4cADjx493+PPU19cjMjISoihi//798hfS+Ph4ZGVl4YUXXpCnM2i1WkRGRuLw4cNISkpCa2srjEYj+vfvj/LycrS2tqK1tRU//fQTYmNjbb6f0uebOHGiPFzXYDCgubkZ/v7+SE5ORmZmJtrb25Gdne3w5yJl5gvc8o5dRCbmvL5kyRKn5vW5c+cC6F5eHzhwYJfzui0HDx6ETqfDqVOn5JFe8fHxyMvLw6pVqyAIAs6fP4/Ro0fDz88PjY2N8rYNDQ2IjIwEAOzbt69bcZixE4FUQRQhT3cwsf7FGBoqOfWWct1huiquc6+I3B3OuEqvdeeC5QMQ7Jab62i1waipqVUot349W2W21nes33ldU+dIcLA6OjMeJW+/XY+6Os4DoodbSkoKUlNTsXXrVgDAqFGjMHr0aEyaNAmDBg1S/APabMyYMZg+fToSExMxYMAAjBs3Ti5bvnw5pk2bhgEDBuCJJ56Qv8jNmDEDy5cvR25uLrZv3y7XN1/k6rXXXpMvrGj+4uqI+fPnY8GCBTh06BB0Op08amDSpEkoKytDcnIy+vTpg8mTJ2PlypXYvHkzVqxYgQ0bNsi3Qhs8eDCmT5+OhIQEREdHY/To0Yrvp/T5PvroI7z11lvYs2cPRFHEmjVrEBMTA09PT+h0Ovj7+z/yd3boKVFRBhw5UoWoKHboEpmZ8/qWLVsAqCOvp6amyhdW7EpetyUoKAjPP/+8fGFFAFiyZAnef/99JCQkQJIkDBgwALt27cKECROQnZ2NKVOmYNGiRVi4cCEyMjKwdetW6HS6bsVhJkidjbdwoc4u5NNT1HSbFDXFAqgrHsaiTE3xPAqxuOv+5O6ihlyspuMGUFc8j1Iszc3NFkPju+tBb5/lCozFNqPRiKSkJOTk5MhTLe5n67hgHnaPRynfOJOaYgHUFY+abv2qptwHqCseR2LpSi7mv5OIiIiIyOnKy8uh0+kQFxen2IFAREQPH05nICIiIiKnGzFiBE6ePKmq/8YREVH3cSQCERERERERETmEnQhERETUI9x4GSZSMR4XRETu15VczE4EIiIi6hGiKHJYO1nQ6/UQRX4dJXpYcbrSo6GruZjXRCAiIqIe4e3tjZaWFrS2tkIQhG6/npeXF1pbW50QWfcxFmVK8UiSBFEU4e3t7YaoiMgZgoOD8c8//zgtr3fHw5L73MFeLA+Si9mJQERERD1CEAT4+Pg47fXUdJszxqJMbfEQkfM4O693h9pyjZricXYsHD9GRERERERERA5hJwIREREREREROYSdCERERERERETkEEHifXWIiIiIiIiIyAEciQDg7bffdncIMjXFAqgrHsaiTE3xMBZ6EGrbV2qKh7EoU1M8jEWZ2uIhZWraV4xFmZriYSzK1BSPs2NhJwIREREREREROYSdCERERERERETkEM0HH3zwgbuDUIMhQ4a4OwSZmmIB1BUPY1GmpngYCz0Ite0rNcXDWJSpKR7Gokxt8ZAyNe0rxqJMTfEwFmVqiseZsfDCikRERERERETkEE5nICIiIiIiIiKHeLg7gJ5SXV2N7Oxs3LlzB4IgICEhAc8995xFnbKyMqxbtw79+vUDAIwbNw6zZs1ySTzp6enw9vaGKIrQaDRYu3atRbkkScjLy8OZM2fg5eWFtLQ0lwyHqaysRFZWlrxcVVWF2bNnY+rUqfI6V7fLli1bUFJSgsDAQGRmZgIAGhsbkZWVhVu3biEsLAwZGRnw8/Oz2vbs2bPIy8uD0WjEs88+i5SUFKfHsnv3bhQXF8PDwwPh4eFIS0tD3759rbbtbJ86I5Z9+/bhu+++Q0BAAABgzpw5GDt2rNW2zm4XpXiysrJQWVkJAGhuboavry/Wr19vta2z20bpfHbXcUOOYR5W5u5crKY8rBQPczHzMDkHc7Ft7s7DgLpyMfNw1+LpdblY6iVqa2uliooKSZIkqbm5WVq8eLF07do1izrnz5+X1qxZ0yPxpKWlSXV1dYrlxcXF0urVqyWj0ShdvHhRWrlypctjMhgMUmpqqlRVVWWx3tXtUlZWJlVUVEhLly6V1+3evVvKz8+XJEmS8vPzpd27d9uMd9GiRdKNGzek9vZ2admyZVb71BmxnD17VtLr9XJctmKRpM73qTNi2bt3r1RQUGB3O1e0i1I8He3cuVPav3+/zTJnt43S+eyu44YcwzzsGHfkYjXlYaV4mIuZh8k5mIs7x+/EzMNdjaej3pCLe810Bq1WK/da+vj4oH///qitrXVzVMp+++03PPPMMxAEASNGjEBTUxNu377t0vcsLS1FREQEwsLCXPo+9xs5cqRVz9jp06cRHx8PAIiPj8fp06ettrt8+TIiIiIQHh4ODw8PTJgwwWa97sby1FNPQaPRAABGjBjRY8eNrVgc4Yp26SweSZJw8uRJ6HS6br+PI5TOZ3cdN+QY5mHHuCMXqykPK8XDXMw8TM7BXNw5fidmHn7QeHpLLu410xk6qqqqwtWrVzFs2DCrsvLycixfvhxarRZz587FwIEDXRbH6tWrAQBTpkxBQkKCRVltbS1CQ0Pl5ZCQENTW1kKr1bosnhMnTige8D3ZLgBQV1cnf1atVov6+nqrOrW1tQgJCZGXQ0JCcOnSJZfGdezYMUyYMEGx3N4+dZYjR46gqKgIQ4YMwbx586ySmDva5Y8//kBgYCAiIyMV67iqbTqez2o9bsga87AyteRiNZ9PzMXWmIfpQTAX26aWPAyoNxczD9vWW3Jxr+tEaGlpQWZmJl555RX4+vpalEVHR2PLli3w9vZGSUkJ1q9fj82bN7skjo8//hjBwcGoq6vDqlWrEBUVhZEjR8rlko2bZgiC4JJYAECv16O4uBgvv/yyVVlPtktX9HQbffXVV9BoNIiLi7NZ3tk+dYbExER57t3evXuxa9cupKWlWdTp6XYB7P+yBVzXNvbOZyXuaB+yxDys7GHLxe5oI+Zi25iHqauYi2172PIwwO/EasnDQO/Jxb1mOgNgSgqZmZmIi4vDuHHjrMp9fX3h7e0NABg7diwMBoPNXhtnCA4OBgAEBgYiNjYWly9ftigPCQlBdXW1vFxTU+PSHtczZ84gOjoaQUFBVmU92S5mgYGB8lC127dvyxdN6SgkJAQ1NTXysivb6IcffkBxcTEWL16seHJ1tk+dISgoCKIoQhRFPPvss6ioqLCq05PtAgAGgwGnTp2y2xvtiraxdT6r7bgha8zD9qkpF6vxfGIuto15mLqKuViZmvIwoL5zinlYWW/Kxb2mE0GSJOTk5KB///6YNm2azTp37tyRe2QuX74Mo9EIf39/p8fS0tKCu3fvys/PnTuHQYMGWdSJiYlBUVERJElCeXk5fH193TZsq6fapaOYmBgcP34cAHD8+HHExsZa1Rk6dCiuX7+Oqqoq6PV6/Pzzz4iJiXF6LGfPnkVBQQFWrFgBLy8vm3Uc2afO0HEO4KlTp2wOoeupdjErLS1FVFSUxXCojlzRNkrns5qOG7LGPNw5NeVitZ1PzMXKmIepK5iL7VNTHgbUdU4xD9vXm3KxINkax/AI+vPPP/Hee+9h0KBBcq/ZnDlz5J7NxMREHD58GEePHoVGo4GnpyfmzZuHxx9/3Omx3Lx5Exs2bABg6rGaOHEiZs6ciaNHj8qxSJKE3Nxc/P777/D09ERaWhqGDh3q9FgAoLW1FQsXLsSnn34qD3/pGIur2+V///sfLly4gIaGBgQGBmL27NmIjY1FVlYWqqurERoaiqVLl8LPzw+1tbXYtm0bVq5cCQAoKSnBzp07YTQaMWnSJMycOdPpseTn50Ov18vzrIYPH44FCxZYxKK0T50dS1lZGf766y8IgoCwsDAsWLAAWq3W5e2iFM/kyZORnZ2N4cOHIzExUa7r6rZROp+HDx/uluOGHMM8bJ87c7Ga8rBSPMzFzMPkHMzFyvid2H4szMPK8fS2XNxrOhGIiIiIiIiIqHt6zXQGIiIiIiIiIuoediIQERERERERkUPYiUBEREREREREDmEnAhERERERERE5hJ0IREREREREROQQdiIQERERERERkUPYiUBEREREREREDmEnAhERERERERE55P/iw41XFMdV6wAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABBgAAAFACAYAAAAWBM9UAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAgAElEQVR4nOzdd3xT9f4/8NfJaNI9EtraUvZqWUU2V1DsAGRfygXFwcVxARUE5SoIXuUnyldBcaCIIIrjXrAFCk5ahohVqWAZItAie3VCaZs045zfH2lD011aepr09Xw8+kjOfp+8aWje+QxBkiQJRERERERERET1oJA7ACIiIiIiIiJyfiwwEBEREREREVG9scBARERERERERPXGAgMRERERERER1RsLDERERERERERUbywwEBEREREREVG9scBARERUB7t374YgCDh//nydjhMEAZ999tktiqrxNMZ9nD59GoIgYO/evXW67l133YVHHnmk3tf/+OOPoVKp6n2e2miomImIiJoCFhiIiMglCYJQ7U+bNm1u6ryDBg3CpUuXEBISUqfjLl26hLi4uJu6Jt2a1+/8+fMQBAG7d+92WD9p0iRcuHChQa9FRETUHDROeZ6IiKiRXbp0yf583759GDt2LPbt24ewsDAAgFKpdNjfZDLBzc2txvO6ubkhODi4zvHczDF0Q2O+fu7u7nB3d2+06xEREbkKtmAgIiKXFBwcbP8JCAgAALRo0cK+LjAwEG+//Tbuu+8++Pr6YsqUKQCA559/HuHh4fDw8EBYWBimT5+Oa9eu2c9bvotE6XJSUhKGDBkCDw8PRERE4Pvvv3eIp3wTf0EQ8N577+GBBx6At7c3wsLC8Nprrzkck5OTg4kTJ8LT0xNBQUFYtGgRHnroIURHR1d77zXdQ2kXgJ9++gm33347PDw80LdvX+zfv9/hPLt27UKPHj2g1WrRo0cP7Nq1q9rrpqenQxAEpKSkOKz/9ddfIQgCjh07BgB46623EBkZCS8vLwQHB2Py5MkOBaHKlH/9zpw5g+HDh8Pd3R2tWrXCO++8U+GYL774Av3794evry/0ej1GjhyJEydO2LeXFpuGDh3q0Kqlsi4S33zzDXr37g2NRoPAwEDMnDkThYWF9u1Tp05FdHQ0Vq9ejdatW8PHxwdjx45FVlZWtfdVntlsxnPPPYfQ0FC4ubkhIiICX3zxhcM+a9asQXh4OLRaLXQ6HYYMGWL/95ifn49//vOfCA4OhkajQVhYGObOnVunGIiIiG4WCwxERNRsvfTSSxg4cCAOHDiAJUuWALB9e7169WocPXoUH3/8MXbv3o1Zs2bVeK5nnnkGCxYswMGDB9GnTx9MmjQJV69erfH6Q4YMQVpaGubNm4dnn33W4UP8P//5Txw8eBBfffUVdu7cifPnz2PLli01xlKbexBFEfPnz8dbb72FAwcOwN/fH//4xz9gsVgAABcvXsSoUaPQu3dvHDhwAMuXL8fs2bOrvW7Hjh0xYMAAfPLJJw7rP/30U/Tr1w9dunSxr1u2bBkOHz6MzZs34+zZs5g8eXKN91VKkiSMHz8eOTk52L17N7Zu3YqtW7fiwIEDDvsVFxdj0aJFOHDgAJKSkqBUKjFy5EiYTCYAsO+fkJCAS5cuITU1tdLrHTp0CGPGjLHn6pNPPsFXX32F6dOnO+yXmpqKXbt24euvv8Z3332HtLQ0PPPMM7W+LwBYsGABPvzwQ6xYsQJHjhzB/fffj/vvvx87duwAAOzfvx/Tp0/H/Pnzcfz4cezevRsPPvig/fiFCxfiwIEDSExMRHp6OjZs2IDw8PA6xUBERHTTJCIiIhf3448/SgCkU6dO2dcBkKZNm1bjsZs2bZLc3Nwkq9UqSZIk7dq1SwIgnTt3zmE5ISHBfsylS5ckANJ3333ncL1PP/3UYfnJJ590uFbnzp2l5557TpIkSTpx4oQEQEpOTrZvN5lMUsuWLaWoqKg63H3Fe1i3bp0EQNq/f799n59//lkCIB07dkySJEl6/vnnpVatWklms9m+z7Zt2yrcR3nvv/++5OfnJxmNRnvMer1eevfdd6s85sCBAxIA6fz585IkSdKpU6ckANKPP/5o36fsdZOSkiQA0vHjx+3bMzMzJa1WKz388MNVXicnJ0cCIO3du1eSJEk6d+6cBEDatWuXw37r1q2TlEqlffn++++X+vbt67DPli1bJEEQpNOnT0uSJEkPPfSQpNfr7fctSZL06quvSsHBwVXGI0mSdOedd9pjLiwslNzc3KSVK1c67DNu3Dhp6NChkiTZcunj4yNdu3at0vONGTNGeuihh6q9JhER0a3CFgxERNRs9evXr8K6TZs2YciQIQgJCYGXlxemTJkCk8mEy5cvV3uuyMhI+/Pg4GAolUpcuXKl1scAQGhoqP2Yo0ePAgAGDBhg365Wq9GnT5/qb6qW9yAIAnr27OlwbQAO1+/Xr59DV4E77rijxmtPmjQJBoMBW7duBWDrWpCfn+/QQmH37t0YNmwYwsLC4O3tbT/vmTNnajx/aWx6vR6dOnWyr2vRogU6d+7ssF9aWhrGjx+Ptm3bwtvbG61atarTdUr98ccfGDJkiMO6O++8E5Ik2fMEAOHh4dBoNPblsvmsjYyMDJhMpkqv9ccffwAAYmJi0K5dO7Rt2xaTJ0/G6tWrkZ2dbd935syZiI+PR7du3TB79mx8++23EEWxTvdLRER0s1hgICKiZsvT09Nh+ddff8XEiRMxZMgQbN68GQcOHMCqVasAwN6sviqVDRBZ0we78scIglDhGEEQqj1HebW9B4VC4TDQZel1Sq8vSVKFa9cmFn9/f4wePRrr168HAKxfvx4jR46ETqcDAJw9exb33HMP2rRpg//973/47bff7MWIml7jUpXFVl5RURFiY2MhCAI++ugj7Nu3D6mpqRAEodbXKauq65VdX1k+JUmq97XK3q+Xlxd+++03bN68GZ06dcKqVavQoUMH+/gZw4YNw9mzZ/H888/DaDTi/vvvx9133w2r1VrnOIiIiOqKBQYiIqISe/fuhV6vx8svv4z+/fujU6dO9sHzGltERAQA4Oeff7avs1gsFQZiLK+h7qFr16749ddfHT6Y7t27t1bHPvjgg/juu+9w/PhxfP3113jooYfs21JTU2EwGLBixQr87W9/Q+fOnev0LX9pbFlZWUhPT7evy87OdhjA8c8//0RWVhaWLFmCoUOHIjw8HHl5eQ4f+EsLAjV9+O7atSt++OEHh3U//PADBEGw56khdOjQARqNpsK19uzZg65du9qXlUolhgwZgsWLF2P//v247bbbHAaCDAgIwL333osPPvgAX3/9NX744QeHlhZERES3CgsMREREJTp37oysrCysXbsWf/31F9avX4/33ntPllg6duyI0aNH4/HHH7d/QPzXv/6F/Pz8ar+9b6h7mDFjBrKysvDYY4/hzz//xI4dO/D888/X6tgRI0YgICAAkydPhre3N+655x6H+xIEAcuXL8epU6ewZcsWLF68uE6xRUVFoWfPnrj//vuxb98+pKWlYcqUKQ7dOVq3bg2NRoN33nkHJ0+exI4dOzB79myH106v18PLywvbt2/H5cuXkZeXV+n15s2bhwMHDmDu3Lk4duwYvvvuOzz55JOYMmWKvdtFQ/Dw8MCsWbOwaNEifPnll0hPT8crr7yCxMRELFiwAACQmJiIN998E/v378fZs2exZcsWnDt3zl7oeP7557Fp0yYcP34c6enp+Pzzz+Hl5dWgcRIREVWFBQYiIqISo0aNwvPPP48FCxage/fu+N///ofXX39dtnjWrVuHbt26YcSIEbjrrrsQGhqKmJgYaLXaKo9pqHsIDQ3Ftm3bsG/fPkRGRmL27Nl44403anWsSqXCfffdh7S0NEyePBlqtdq+rUePHnjnnXfwwQcfICIiAsuWLcOKFSvqFJsgCNiyZQt8fX0xZMgQjBo1Cvfccw9uv/12+z56vR6fffYZkpKS0LVrVzzzzDNYtmwZFIobf/ooFAqsXLkSGzduRFhYGHr16lXp9Xr06IGtW7fihx9+QM+ePfHAAw9g5MiR9q4nDWnJkiV49NFH8dRTT6Fr16747LPP8NlnnyEqKgqArQvKtm3bMHz4cHTq1An//ve/sXDhQkybNg0AoNVq8cILL6B3797o06cPDh06hG+//Ra+vr4NHisREVF5gnQznQOJiIio0VmtVnTp0gVjxozB8uXL5Q6HiIiIyIGq5l2IiIhIDnv27EFmZiZ69eqF69ev480338Tp06cxdepUuUMjIiIiqoAFBiIioibKarXi5ZdfRkZGBtRqNbp164Zdu3ahe/fucodGREREVAG7SBARERERERFRvXGQRyIiIiIiIiKqNxYYiIiIiIiIiKjeWGAgIiIiIiIionprsoM8Xrx4Ue4QqAHp9XpkZ2fLHQbdIsyv62OOXRvz69qYX9fG/Lo25te1OWt+Q0JCqtzGFgxEREREREREVG8sMBARERERERFRvbHAQERERERERET11mTHYCAiIiIiIiLXIkkSjEYjRFGEIAhyhyOrK1euoLi4WO4wKiVJEhQKBbRabZ3yxAIDERERERERNQqj0Qi1Wg2Vih9FVSoVlEql3GFUyWKxwGg0wt3dvdbHsIsEERERERERNQpRFFlccBIqlQqiKNbpGBYYiIiIiIiIqFE0924Rzqau+WKBgYiIiIiIiJqF3NxcxMTEICYmBpGRkejdu7d92WQyVXvswYMHsWjRohqvMWbMmAaJNSUlBQ8++GCDnKuxsG0KERERERERNQsBAQFISkoCACxfvhyenp6YPn26fbvFYqmyC0fPnj3Rs2fPGq+xdevWhgnWCbHA0ADUaWlQnTwJU8+esLZrByjYMISIiIiIiMgZPPXUU/Dz88ORI0fQvXt3jBkzBv/5z39gNBqh1WrxxhtvoEOHDkhJScGqVauwfv16LF++HBcuXMDZs2dx4cIFPPLII3j44YcBAB07dkR6ejpSUlLwxhtvwN/fH8ePH0ePHj3wzjvvQBAE7NixA4sXL4a/vz+6d++OM2fOYP369VXGmJeXh6effhpnz56FVqvFa6+9hoiICPz888944YUXANi6M2zatAmFhYWYMWMGrl+/DqvVildffRX9+/dvlNeSBYYG4L55M7zWrAEAiD4+MHfvDlNkJMw9esAcGQlraCjAvkZERERERERN0l9//YUNGzZAqVTi+vXr2LRpE1QqFfbs2YP/+7//w4cffljhmIyMDHz55ZcoLCzE4MGD8eCDD0KtVjvsc+TIEezcuRPBwcEYO3YsUlNT0aNHDzz77LNITExEaGgoZs6cWWN8y5cvR7du3fDRRx9h7969mD17NpKSkrBq1Sq88sor6Nu3LwoLC6HRaPDZZ5/hzjvvxOzZs2G1WmEwGBrsdaoJCwwNIH/RIhRNngz1wYNwS0uD+uBBeK1eDcFsBgBYdTqYe/aEOTISppJHUa+XOWoiIiIiIiL5vPCCD44eVde8Yx1ERJixeHF+nY8bNWqUfcrI/Px8PPXUUzh16hQEQYC55HNdeVFRUdBoNNBoNNDr9cjKykJISIjDPpGRkfZ1Xbt2xblz5+Dh4YHWrVujdevWsFgsGDduHD777LNq49u3b5+9yHHHHXcgLy8P+fn56Nu3L1566SWMHz8eI0aMQEhICCIjI/H000/DYrFg2LBh6NatW51fj5vFAkNDUKlgCQ+HJTwchsmTbeuKi6H+80+o09LgdvAg1AcPQrNrFwRJAgBYQkJgjoyEuWdPW9GhZ09IPj4y3gQREREREVHz5OHhYX/++uuvY9CgQVi7di3OnTuHuLi4So/RaDT250qlElartcI+bm5uDvtYLJabik8q+RxZliAIeOKJJxAVFYWdO3di9OjR2LBhAwYMGICEhATs2LEDs2fPxvTp0zFx4sSbum5dscBwq2g0tgJCZCSKSlYJhYVQHz4MdVoa1IcOwe3gQbh/8439EEu7drauFSUFB3O3bpDc3eWJn4iIiIiI6Ba6mZYGjeH69esIDg4GAGzcuLHBz9++fXucOXMGZ8+eRUhISK0GhRwwYAA2bdqEOXPmICUlBQEBAfD29sbp06cRHh6O8PBw7N+/HxkZGdBqtQgODsaUKVNQVFSEw4cPN60CQ1paGtatWwdRFBEVFYVx48Y5bE9NTcWGDRsgCAKUSiWmTp2KLl26IDs7GytXrsTVq1chCAKio6Nxzz333JIbcQaSpydMAwbANGCAfZ2Qlwe3Q4dsRYeDB6FJSYHHpk22/ZVKWDp1ulF0iIyEuUsXQN2wzYiIiIiIiIjIZsaMGXjqqaewevVq/O1vf2vw87u7u+OVV17BvffeC39/f0RGRtZ4zNy5czF37lxER0dDq9VixYoVAIA1a9YgJSUFCoUCnTp1wtChQ5GYmIhVq1ZBpVLB09MTb731VoPfQ1UEqbK2FmWIoojZs2dj4cKF0Ol0mD9/PmbPno2WLVva9zEajdBoNBAEAWfOnMGbb76JFStWIC8vD3l5eWjXrh0MBgOee+45zJs3z+HYqly8eLH+d+ekFJcv21o4lBQd3NLSoLh6FQAgaTQwR0Tc6FoRGQlL+/ZASX+hpkqv1yM7O1vuMOgWYX5dH3Ps2phf18b8ujbm17W5Yn6LioocuiM0V4WFhfD19YXZbMaCBQvQtm1bPPbYY3KHVUFl+So/zkRZNbZgyMjIQHBwMIKCggAAgwYNQmpqqkORQKvV2p8XFxdDKJkxwd/fH/7+/gBsVZrQ0FDk5ubWqsDQnInBwSgODkZxbKxthSRBefasbTyHQ4egPngQ7l9+Cc+PP7bt7+lpm7GiZ0+YSmeuaNWKM1cQERERERE1QZ9//jni4+NhMpnQrVs3PPDAA3KH1CBqLDDk5uZCp9PZl3U6HdLT0yvst2/fPnzxxRe4du0a5s+fX2F7ZmYmTp06hQ4dOtQz5GZIEGBt3RrW1q1hHDvWts5qherkSYdBJD0/+gheJpNts7+/fSyH0i4WYkmRiIiIiIiIiOTz2GOPYebMmTc96GNTVWOBoarRKsvr168f+vXrh6NHj2LDhg1YtGiRfZvRaMTy5csxderUKpvDJCcnIzk5GQCwdOlS6DmNY82CgoBBg+yLZpMJwh9/QPjtNwj798Ptt9+gefddCCWjmUohIZB694bYpw+k3r0h9e4NBAQ0SqgqlYo5dWHMr+tjjl0b8+vamF/Xxvy6NlfM75UrV6BSca6BUk39tSidgrO2arwbnU6HnJwc+3JOTo6920NlIiIisHLlSuTn58PHxwcWiwXLly/H4MGD0b9//yqPi46ORnR0tH3Z1foaNZqwMNvP+PEAAMFggPrIEahLWjm4paVBtW2bfXdLmza2sRz69IFhzBiIt+gNzBX7j9ENzK/rY45dG/Pr2phf18b8ujZXzG9xcTGUTXz8uMaiUqmafAuG4uLiCv8G6zUGQ/v27XHp0iVkZmYiICAAKSkpmDVrlsM+ly9fRlBQEARBwF9//QWLxQJvb29IkoRVq1YhNDQUo0aNuslbovqQ3N1h6tsXpr597euEa9fs02SqDx6E22+/wSMxET4vvQRjVBSKJk9G8dChnK2CiIiIiIiIaq3GAoNSqcS0adOwZMkSiKKIoUOHIiwsDNu3bwcAxMbG4pdffsGePXugVCrh5uaGOXPmQBAEHDt2DHv27EGrVq0wb948AMC9996L22+//dbeFVVL8vWFafBgmAYPtq9TnTgBj40b4R4fD/fvv4dVr4dhwgQUTZoES+fOMkZLREREREREzqDGaSrl0pynqZSV2QzNrl3w2LgR2qQkCBYLTJGRKPrHP2AYNw6Sr+9NndYVm3fRDcyv62OOXRvz69qYX9fG/Lo2V8yv3NNUxsXF4YknnsBdd91lX/fhhx/ir7/+wquvvlrlMYsWLULPnj3xwAMP4N1334Vvuc9Fy5cvh6enJ6ZPn17ltb/77ju0a9cOnTp1sh/Tt29fDBkypF73lJKSglWrVmH9+vX1Ok9l6jpNpaLBIyDnplajODYWeWvW4MqBA7j24osQiovht2ABgm+/HX6PPw7Nnj2AKModKRERERERUZ2MHTsWiYmJDusSExMxbty4Wh3/6aefVigu1NZ3332HEydO2JefffbZehcXmhoWGKhKok6HwkcfRVZSErK+/RZFkydDu3s3dPfei8D+/eH92mtQnj4td5hERERERES1MnLkSCQnJ6O4uBgAcO7cOVy5cgX9+vXDc889hxEjRmDo0KFYtmxZpcf3798fubm5AIC33noLgwcPxqRJk3Dy5En7Pp9//jnuueceREdH49FHH4XBYEBqaiqSkpLw8ssvIyYmBqdPn8asWbPw1VdfAQB+/PFHxMbGIioqCnPnzrXH179/fyxbtgzDhg1DVFQUMjIyqr2/vLw8TJs2DdHR0Rg1ahSOHj0KAPj5558RExODmJgYxMbGoqCgAFeuXMHf//53xMTE4O6778avv/5avxcXLDBQbQgCzD164NqSJbi8fz9y338fls6d4fX22wj629+gi4uD+8aNEIqK5I6UiIiIiIioSgEBAYiMjMTu3bsB2FovjBkzBoIg4Nlnn8W3336L5ORk/PLLL/YP55U5dOgQtm7diu3bt2PNmjU4ePCgfduIESPwzTffIDk5GR06dMB///tf9O3bFzExMVi4cCGSkpLQpk0b+/5GoxFz5szB+++/jx07dsBisTh0dwgICMD333+PBx54AKtWrar2/pYvX45u3bohOTkZzz33HGbPng0AWLVqFV555RUkJSVh8+bN0Gq12Lx5M+68804kJSUhKSkJXbt2vYlX1FHTnnSTmh6tFsYxY2AcMwaKixfhER8Pjw0b4D9nDsSFC2EYPRqGSZNss1YIgtzREhERERFRE+XzwgtQV/Mh/maYIyKQv3hxtfuMGzcOiYmJGDZsGBITE/HGG28AALZt24bPP/8cVqsVV65cQXp6OiIiIio9x6+//orhw4fD3d0dABATE2Pfdvz4cbz22mvIz89HYWEh7rzzzmrjOXnyJFq1aoX27dsDACZOnIhPPvkEjz76KABbwQIAevTogW+//bbac+3btw8ffvghAOCOO+5AXl4e8vPz0bdvX7z00ksYP348RowYgZCQEERGRuLpp5+GxWLBsGHD0K1bt2rPXRtswUA3TQwJQcGsWcjcuxfZmzfDMHo03Ldtg378eAQOHgyvd96B4tIlucMkIiIiIiKyGz58OPbu3YvDhw/DaDSie/fuOHv2LD744ANs2LABycnJiIqKgtForPY8QhVfqM6ZMwcvv/wyduzYgTlz5ti7O1SlpnkXNBoNANsMj1artc7nEgQBTzzxBF5//XUYjUaMHj0aGRkZGDBgABISEhAcHIzZs2fjyy+/rPbctcEWDFR/ggBTv34w9euH/MWLof3qK3hs3AifpUvh/dprKL7zTigeeQQYOBAo+eUgIiIiIqLmraaWBreKp6cnBg4ciLlz59oHd7x+/Trc3d3h4+ODrKws7Nq1CwMHDqzyHAMGDMCcOXPw+OOPw2q1IikpCQ888AAAoKCgAEFBQTCbzdi8eTOCg4MBAF5eXigsLKxwrg4dOuDcuXM4deoU2rZti4SEBAwYMOCm7m3AgAHYtGkT5syZg5SUFAQEBMDb2xunT59GeHg4wsPDsX//fmRkZECr1SI4OBhTpkxBUVERDh8+jIkTJ97UdUuxwEANSvL0hGHSJBgmTYLy9Gl4bNwIj40boZwyBcF+figaPx6GSZNg7taNXSiIiIiIiEgW48aNwyOPPIL3338fANC1a1d069YNQ4cORatWrdC3b99qj+/evTtGjx6N2NhYtGzZEv3797dvmzdvHkaNGoWWLVuiS5cuKCgoAGCbwWLevHlYu3YtVq9ebd9fq9XijTfewL/+9S9YrVb7dJg3Y+7cuZg7dy6io6Oh1WqxYsUKAMCaNWuQkpIChUKBTp06YejQoUhMTMSqVaugUqng6emJt95666auWZYg1dQeQyYXL16UOwRqKFYrWhw6BPOHH8L9u+8gFBfDHB6OokmTYPj73yHqdHJHSPXkinM0kyPm2LUxv66N+XVtzK9rc8X8FhUVwcPDQ+4wmgSVSgWLxSJ3GNWqLF8hISFV7s8xGOjWUyohxcTg6nvv4fKBA7j6yiuQNBr4vvgignr3hv+jj0KTlAQ08V8uIiIiIiIiqhq7SFCjkvz8UPTQQyh66CGojh2Dx4YNcE9IgPs338AaGAjDhAkomjQJlo4d5Q6ViIiIiIiI6oAtGEg2li5dkP+f/+DK/v3I/egjmHr1gueHHyLwrrugHzUKHp99BiE/X+4wiYiIiIiIqBZYYCD5qdUwDhuGvI8+wpXffsO1RYsgFBXB79lnEdSrF/yefBJuP/4IiKLckRIRERERUT000SEAqQp1zRcLDNSkiC1aoHD6dGTt2IGsr7+G4R//gDY5GfrJkxE4cCC8ly2D8uxZucMkIiIiIqKboFAomvzAhmRjsVigUNStZMAxGKhpEgSYIyNxLTIS1154Ae7ffw/3DRvgtWIFvN98E8WDBqFo0iQYR46E5O4ud7RERERERFQLWq0WRqMRxcXFEJr5tPUajQbFxcVyh1EpSZKgUCig1WrrdBwLDNT0ubvDMG4cDOPGQXnhAty//BIeGzfCf/ZsiM8/D8OYMSi67z6Ye/WSO1IiIiIiIqqGIAhw5xeEAFxzGlJ2kSCnYg0NRcFTTyFz715kx8fDOGIE3DdvRotRo+D7739DKCiQO0QiIiIiIqJmiQUGck4KBUwDB+LqihW4kpaG648/Do///hctoqPhlpIid3RERERERETNDgsM5PQkLy9cX7AA2Zs2AUol9BMnwueFFyAYDHKHRkRERERE1GywwEAuw9y3L7KSklAwbRq81q5Fi9hYqPfvlzssIiIiIiKiZoEFBnIpkocH8v/f/0P2hg1AcTH048bB+9VXgSY6OisREREREZGrYIGBXJLpjjuQtWMHiiZNgve776LFyJFQHTkid1hEREREREQuiwUGclmStzeuLVuGnE8+gSInBy1GjoTXihWAxSJ3aERERERERC6HBQZyecXR0bVPfQ8AACAASURBVMjcsQOGUaPg8/rr0I8dC1V6utxhERERERERuRQWGKhZkAICcHXlSuSuWgXlmTNoMWwYPD/4ALBa5Q6NiIiIiIjIJbDAQM2KcfRoZO3aBeNdd8F38WLoJk6E8vRpucMiIiIiIiJyeiwwULMjtmiBvLVrkbdiBdR//okWMTHwWL8ekCS5QyMiIiIiInJaLDBQ8yQIMEyciMzkZJj69IHf/PkIuO8+KC5ckDsyIiIiIiIip8QCQwP47Tc13nnHS+4w6CaIoaHI/eILXF26FG6//YbAqCi4b9zI1gxERERERER1xAJDA/jxRw2WLvXB+fNKuUOhmyEIKHrgAWQlJ8McEQH/OXPg//DDUGRlyR0ZERERERGR02CBoQFMmGAAAGza5C5zJFQf1tatkRMfj2v/+Q+0u3ejxdCh0G7bJndYREREREREToEFhgbQqpUVAwYUIz7enS3rnZ1CgcLHHkPW99/D2ro1AqZPh9/MmRByc+WOjIiIiIiIqElT1WantLQ0rFu3DqIoIioqCuPGjXPYnpqaig0bNkAQBCiVSkydOhVdunSp1bGuYsIEA+bN80Namhq9epnlDofqydKxI7ITE+G1ciW833wTmp9/xtXXXkNxTIzcoRERERERETVJNbZgEEURa9euxYIFC/Dmm2/ip59+wvnz5x326d69O15//XW8/vrrmDFjBlatWlXrY13FqFEGaDQS4uM95A6FGopKhYLZs5H11VcQdTropk6F79NPQ7h+Xe7IiIiIiIiImpwaCwwZGRkIDg5GUFAQVCoVBg0ahNTUVId9tFotBEEAABQXF9uf1+ZYV+HjI2HYMCO2bHGHySR3NNSQLN26Ievrr3H9ySfhsXEjWkRFwe3HH+UOi4iIiIiIqEmpscCQm5sLnU5nX9bpdMitpD/6vn378NRTT+HVV1/FjBkz6nSsq4iLK8LVqwrs3KmVOxRqaBoNrj/3HLITEwGNBvrJk+GzcCGEoiK5IyMiIiIiImoSahyDQapk1MLSFgpl9evXD/369cPRo0exYcMGLFq0qNbHAkBycjKSk5MBAEuXLoVer68x+KZmwgTgmWckbNvmh/vvt8gdTpOiUqmcMqcVxMZC3L8f1hdegNc778Bzzx5Y1q6FNHCg3JHJymXyS1Vijl0b8+vamF/Xxvy6NubXtblifmssMOh0OuTk5NiXc3Jy4O/vX+X+ERERWLlyJfLz8+t0bHR0NKKjo+3L2dnZtbqBpmbsWB98/LEn0tNz4O/PKSVK6fV6p81ppZ57Dm5DhsBv7lyohg5F4fTpyH/mGUDbPFuvuFx+qQLm2LUxv66N+XVtzK9rY35dm7PmNyQkpMptNXaRaN++PS5duoTMzExYLBakpKSgT58+DvtcvnzZ3lrhr7/+gsVigbe3d62OdTVxcUUwmwVs3eoudyh0i5kGDUJWcjKKpkyB1/vvo8WIEVAfOiR3WERERERERLKosQWDUqnEtGnTsGTJEoiiiKFDhyIsLAzbt28HAMTGxuKXX37Bnj17oFQq4ebmhjlz5tinrKzsWFfWtasF4eFmxMd74KGH2D/f1UleXrj2f/8H4/Dh8HvmGehHj0bBrFm4PmsWoFbLHR4REREREVGjEaTKBkpoAi5evCh3CDft/fc98fLLvtiz5wrat7fKHU6T4KzNf+pCuHoVvi+8AI+EBJi6d8fVFStg6dJF7rAaRXPIb3PHHLs25te1Mb+ujfl1bcyva3PW/NariwTV3fjxBigUEhISPOQOhRqR5OeHq2+/jdw1a6C8eBEtRoyA13vvAVYWmYiIiIiIyPWxwHALBAeLGDy4GAkJ7hBFuaOhxmYcMQJZu3bBGB0NnyVLoB8/Hsq//pI7LCIiIiIioluKBYZbJC7OgPPnVdi3z03uUEgGok6HvNWrkffuu1BlZKBFTAw81q0DK05EREREROSqWGC4RYYPN8LTU0R8PGeTaLYEAYbx45G5cydMgwbBb+FC6CZPhvL8ebkjIyIiIiIianAsMNwiHh4SRo40Yts2dxgMckdDchKDg5G7fj2uvv461GlpaBEVBff//Q9omuOrEhERERER3RQWGG6huLgiFBQosH27Vu5QSG6CgKL77kPWjh0wd+8O/6efRsCDD0Jx+bLckRERERERETUIFhhuoYEDTQgJsSA+nrNJkI01LAw5Gzfi2uLFcEtJQWBUFLSJiWzNQERERERETo8FhltIoQD+/ncDdu/WIDOTLzWVUChQ+PDDyNq+HZZ27RAwcyb8H34Y7gkJttkmWGwgIiIiIiInxE+9t1hcnAGiKGDzZg72SI6s7dsje8sW5M+fD81PP8F/1iwEDR6M4G7dEHD//fBevhyanTsh5ObKHSoRERERETUUgwGapCQon3vO5b5cVMkdgKvr2NGCyEgT4uM98K9/FcodDjU1SiUKnngCBTNmQHXiBNx+/x3q33+H2++/Q7NiBYSSaS0tbdrAdPvtMPfqBVOvXjBHRAAajczBExERERFRbSgyM6FNToYmKQmaPXugMBoheXtDee+9sIaGyh1eg2GBoRHExRVh4UI/HD2qQkSERe5wqClSKmEJD4clPBy47z4AgFBYCPXBg/aigyYlBR6bNgEAJDc3mLt2tRUbSooO1jZtAEGQ8SaIiIiIiAgAIElQHTsG7fbt0CYlwe333wEAltBQFN17L4pjYuA9ahSs16/LHGjDYoGhEYwda8SLL0pISPBARES+3OGQk5A8PWEaNAimQYPs6xQXL8KtpIWD+vff4fHf/0Lx0UcAAKu//40WDr16wRQZCcnfX67wiYiIiIiaF5MJml9+gSYpCdrt26E6f962ulcv5M+bB2NsrO0LxZIvBb01GoAFBqqrgAARUVFGbNrkjvnz86Hiq043SQwJgTEkBMaRI20rLBaojh936FrhvWsXhJK+XJa2bWHq1cvevcIcEQG4ucl4B0REBIMB6vR0qP78E+oTJyAUFAAqFSSl0jZCdPnnCgWgVDo8l1Qq2/Zyz6FU2o4t81zw94emsLDC+gr7llyvts+h4FBeRERCXh60O3dCm5QEze7dUFy/DkmrRfHgwSiYNQvG6GiIQUFyh9lo+FG3kcTFGfD99+7Yu1eDu+4qljscchUqFSxdu8LStStw//0AAOH6dceuFXv33uhaodHc6Fpx++22rhWtWrl21wqDAcqsLCiuXIEyMxOKzMyKjzk5gCTd+CO+5A9n+7JCYVsu3SYIDs/tf6SX3a/keflt9j/Qy5y7xmNLrlH+WPs2tRrWoCBYW7aEtWVLSJ6ecr/qRAQAViuUZ85AfewYVMeOQf3nn1AfOwbl6dP2MXYkjQailxcEqxUQRcBisW2zWm3PG2jwL12DnKUiSaWC5OkJ0d/f9hMQUKtHqNW3KCIioltP+ddfN7o+pKZCsFphbdEChtGjYYyJgWnwYEjuzXOQfxYYGklUlBF+fiLi491ZYKBbSvL2humOO2C6446SFRKUFy9CfeDAja4Vn38Oxdq1AABrQMCNrhW33w5Tz56Q/PxkvINakCQIV686Fg6ysqC8csVWMLhyxbacmQlFfsVuSZJCAbFFC1hbtIAYGAhLRAQkhcL2B77Vajt/meewWm/88V/yU3ZZMJtty2X3LXkOq9X2YaH0A4MoOixX2Lf8cTfB6u8Pa1iYveBgbdkSlrAwWENDYQ0Lg+TjU98MEFE5iuxsW4uE0mLCsWNQHT8OhcEAAJAEAdbWrWHu0gWGMWNg7tLFNvZOmzaotmlj6XtC+cJD6fPS95Fqnvt5e+NaTk7N+5cUOOzvcbV8LhQWQpGXB0VuLhSZmVAdO2ZbLiqq8rZEb2/HwkPZAkVVRQkObkxEcrFY4LZ/v62VwvbtUJ88CQAwh4ej4PHHYYyNhblnT7bsAgsMjUajAUaPNuDLL91x/boAb2/Xmo6EmjBBsH2wDA2FcfRo2zqz2da14sABuKWlQf377/DeufNG14p27Ry7VoSHN07XCosFiuxsW2GguhYHWVkQiisW6kStFmJQEMQWLWDp1AnFgwfbCglBQRADA2ENDIQYGAhRp7O1CHAG5QsTpYWNMsUIwWSC4tIlKC9cgOrcOSjPn4fy/Hmo0tOh2bkTCqPR8ZS+vrCGhtqKDmWKENawMFhCQ21jd7hyqxaiehAMBqiOH3dokaA6dgzK7Gz7PladDpYuXVB0332whIfbigmdO0Py8LiJCwq2AoRKhbJ/OdTlrwhJr4epTHyNxmi8UXgofSx9XvpTsk6VkWFbLiio8nRiaUuJqlpHVNKKAs30G0Qiqj+hoACa3buh3b4dmp07oczLg6RWo3jgQBT+858ojo6GNSxM7jCbHEGSmubEmxcvXpQ7hAb3229qjB3bAm+8kYdJkwxyh9Oo9Ho9suX444ZqTcjPd+ha4fb771BmZQEo6VrRrZtD0cEaFmb/EFpTfoWiohsFgitXquyyoMjJqbQ5sOjnZy8OWAMDIQYF2VofBAU5rJe8vfnBuDxJgiI3F8oyhQfl+fMOhYjyf9CLnp4VWj94hocjz9cX1pYtIer1fJ1dDN+jK2G1QnnqFNSlrRFKCgrKM2fs71OiVgtL586wdOkCc8mPJTwcYosWMgfvyKnyW1wMxdWrjkWJ6ooTeXmVtlQrJbq724sNkr8/rCWPZYsQ1oAAW/E5MBCin5/TfQPpVPmlOmN+G5fywgX7AI2an3+GYDJB9POD8e67YYyNRfFdd9n+3mwgzprfkJCQKrexwNCIJAm4445AhIRY8eWXOXKH06ic9ZenWZMkKC9ccOha4Xb4MISSb8OtOp29a4V7v34ouHjRseVBmS4LlX0jJSmVttYFpQWCkpYH9gJC6foWLdgs9lYq7W5StvXDuXM3li9cgOLqVYdDRK3W3t3C/tiyJSwlrSDEwECn+wO9uWvW79GSBEVmpq2IULaLQ3q6/f1OUihgbdPGVkQID7cXFKytWztFayiXz6/ZXHVRonxxIjfXtm+597VSkkoFUa+3/R9U+n+SXm///6jso+Tp2SSKrS6f32aO+b3FRBHqQ4egLSkqqI8eBWAbKN0YGwtjbCxMffpU35WtHpw1vywwNCFvvumFZct88OuvV9CypVXucBqNs/7yUDlms+3bvDJFB3VGhsMuort7hZYFlbU8EAMC+CHUSQjXr0NfWIj8Q4cqdMNQnjsHZW6uw/6SmxusISEVxn4o7YZhDQq6Zf9R081pLu/RQmHhjfERSlokqI4dgzIvz76PNTDQ1hKhTIsEc8eOTt3Uvrnkt04sFiiuXbMVHLKzbUXxrCx7NzxF2efZ2bbxJsoR3d1trR7KFyTKPIqBgbDq9be0UM78ykSSoDx3DkJ+Pqzt2t1cF6haYH5vAYMBmr17bUWF5GQor1yBpFDA1LevragQHQ1rhw6NEoqz5pcFhibk7FklBg4MwrPP5mPWrKr7GboaZ/3loZoJ165Bn5ODXEmCGBQEyctL7pDoFqjud1goKnIsOJQvQmRmOuwvKZX2AoS1ZUtYQ0MhenkBbm6QSn6g0UBSq288L7+tsudqdZP4NtEZudx7tMUC1alTthYJJUUE9bFjUJ09a99F9PCApXNnhxYJlvBwW/HTxbhcfhub1Wpr/VCmCGEfSLjMoyIry6FYVZbo62srsJcvPpSuK1m+mTGCmN/GocjMhDotDW4HD0Jd8lO2wG4JDYWlY0dYOnSwPZY8F3X1m8OF+W0YisxMaHfsgGb7dmj27IHCaITo6Yniu+6yFRXuvhuSDO//zppfFhiamAkTdMjKUuCHH7Kazd/CzvrLQ7XD/Lq+euXYaLQVHS5cqHQsCMXlyw02FZ9UtuDg5lblMkqKF5JG41DYcFiublv54kZpa5zSN/VKHu13WM0+FR6r2Fbpuepy3nIx6XQ65OTkwP5fUtl8lD6vz7oyzx3+22uIc4siVOfOOQ66mJFhHwhWUiphadfOsUVCly62cWSaSSsqvkc3IpPJNlhx2RYQZR7tAxlnZUFRWFjhcEmhgKjTObaGKClClO+mIfn6AoLA/N4CwrVrtnGpSgoJbmlpUF66BMCWI0unTjD37AlTz54QAwKgOnkSqowMqNLTbQOWlhlc2ervf6Pg0L69/bk1NLRW70HM702SJKiOHbsxleTvvwOwFYKKY2Js4ykMGCB7N1xnzW91BQa2UZXBhAkGzJvnh7Q0NXr1MssdDhHRraXVwtq+Pazt21e+3Wq1fRgsLoZgMkEwmRyel1+GyQShiuVKt5V7rrh+3WG9UFxccbkZuk3uABqANTgY5vBwFA8ZcmPQxQ4dAK1W7tCouXBzgxgSArGaP75LCYWFFVtFlLaEKFlWnThhmznJXPHvRcnNDdYWLaBo0wa+rVvbPrx26ABLhw62ApoTjA/SFAgGA9RHjkCdlmYvJqhOnbJvt7Rpg+J+/WDu2RPmyEiYu3Wzjb9RFVG0FdXLFBxU6enQfvONQwsX0d3dIWf2IkTbto0zc5crMpng9ssvtq4PSUlQnTtnWx0Zifx582CMiYElIoKtHW8xtmCQQX6+gMjIYNx7bxGWLLkmdziNwlmrc1Q7zK/ra1Y5liTAbK68uFFF4QOSVPFb9jL/vQpVbavusfx/z6UtAKrbt6bHMucqex5PLy8UlnybKpVv6VBWZduqaiFRxbpbcX7rbbfB3LmzbYpVqqBZ/f66otLBeEtbQ2Rn3yhIXLkC7ZUrkP78E8qcGwOIS25utpY7ZT/AdugAS/v21X84dnUmk20sqbQ0qA8dshUTTpywj7FhDQ6GKTLSXkwwde/eoO8ritxcW9Gh9Ccjw/Zz/rx9H0mphLVVK5hLCg7uvXohLzgYlg4dGnT2Alch5OVBu3MntElJ0OzeDcX165C0WhQPHgxjTAyM0dEQg4LkDrNKzvr+zC4STdCMGf7Ys0eD33+/3CyKlM76y0O1w/y6PubYtTG/ro35dW2l+RVyc21N9U+ehLrMt+fKs2chiKJ9f0tIiEPBofS5GBTkWt/sWq2216LsuAlHj9pbqYl+fvZiQumjXB9EhaIiW+7KFx5OnXJovWItKTSYS8d6KGn5IAYGOn/uJAlCQYF9lhchL8/+vOyPUPr82jXbY2YmBFGEtUULW0EhJgamwYMhOcnAvM76/swuEk1QXFwRtm51x86dWgwfbqz5ACIiIiKiKkgBATAHBMDcty8MZTcUF0N1+vSND60ZGVCdPAmPDRscxoEQvbwciw6lH2Jbt276TfZLZnRwKCYcOmS/P9HDA+YePVA4dSpMJa0TrK1aNZkP5ZKHB8zdu8PcvbvjBrMZ+vx8FKSmOnS58Ni40TF3Pj4OOTOXPLe2atX4XWUsFijy828UAiorDpQrHgglBYPKZmspJWq1kPz8IPr7Q/Tzg6VtW4h+fhBvuw3GoUNhjoxsNuPqNHUsMMjkzjuLoddbkZDgzgIDEREREd0aGg0snTvD0rmz43pJguLyZXvBQZWRAXVGBjQ//QSPhIQbuymVsLZubfvQWq7lg+Tn18g3Y1PdjA6SmxvMXbvCMHEiTD16wBwZaRuLxRnHpFCrgc6dYSw/E4UkQXHpkj1npS0fNDt3wmPDhhu7lXaVKSk42Fs+tGtX89S7xcWORYBr1yoUBhyKBqU/+fnVnlb09rYVBvz8IPn5wRwaal8WSwoIUtllX1+Ivr5OPVVwc8MCg0xUKmD8eAM+/tgTeXkC/P2bZE8VIiIiInJFggDxtttguu02mAYPdtxUUHBjZoQyrR60u3fbxp0pYdXrbxQcyjTbr+0MCbUKs6YZHTp3hjE29sYgjF26NP0WF/UlCBBDQmAKCYFpyBDHTVev2nOmLik8qI8cgfbrr+1j70iCAGtYmC1XgYFQ5Oc7FA+Eq1ehMBgqu7LteIXCXiAQ/fwglvw7cFhX7kfy94fo42P7EEQujRmWUVxcET780Atbt7rjoYeK5A6HiIiIiAiSl5ftA3vPno4bLBYoz51zaPWgysiA+9dfQ3H16o3jtdob35yXNtkvmU2our7xQlFRxRkdTp++cfk2bVDcv7/jjA4eHg19+05N8vODuU8fmPv0cewqYzRC9ddfttYOJ0/eKD788Ye9CGBp1QpS9+6VFwfKLnt5sTsCVYkFBhl17WpBly5mxMd7sMBARERERE2bSgVr27awtm2L4pgYh02KnBzHFg8ZGVAfPAjttm03Zq0BYGnZ0mFmC0iSvYWC6vhx+4CUpTM6FE2aZJvRoUcP2bpkuAStFpaICNs0jUS3EAsMMhIEWyuGl1/2xcmTSrRvX/XAJkRERERETZWo08Gk08HUv7/jBqMRqlOnHLpaqDIy4PHrr/Zm+FZ/f5gjI2EcNsw2CKOMMzoQUf2wwCCz8eMNeOUVHyQkeODf/74udzhERERERA1Hq4UlPByW8HDH9aJoG0tBFGFt2bLJzOhARPXDzjMyCw4WMXhwMRIS3FFmimIiIiIiItelUMAaGgprWBiLC0QupFYtGNLS0rBu3TqIooioqCiMGzfOYfuPP/6IxMREAIBWq8UjjzyCNm3aAAC++uor7Ny5E4IgICwsDDNnzoSbq4/sWkdxcQY8+aQ/9u1zw4ABppoPICIiIiIiImpiamzBIIoi1q5diwULFuDNN9/ETz/9hPPnzzvsExgYiBdffBHLli3DhAkTsHr1agBAbm4uvv32WyxduhTLly+HKIpISUm5NXfixIYPN8LTU0R8POd3JSIiIiIiIudUY4EhIyMDwcHBCAoKgkqlwqBBg5CamuqwT+fOneHl5QUA6NixI3JycuzbRFGEyWSC1WqFyWSCv79/A9+C8/PwkDBypBHbtrmjmilniYiIiIiIiJqsGgsMubm50Ol09mWdTofc3Nwq99+5cyd69eoFAAgICMDo0aMxY8YMPPbYY/Dw8EDP8vPpEgDbbBIFBQps366VOxQiIiIiIiKiOqtxDAapzLy1pYQqBmI5cuQIdu3ahcWLFwMACgoKkJqaipUrV8LDwwNvvPEG9uzZgyFDhlQ4Njk5GcnJyQCApUuXQq/X1+lGnN3o0UBYmITERD88/LBF7nAanEqlanY5bU6YX9fHHLs25te1Mb+ujfl1bcyva3PF/NZYYNDpdA5dHnJycirt5nDmzBl88MEHmD9/Pry9vQEAhw8fRmBgIHx8fAAA/fv3x4kTJyotMERHRyM6Otq+nJ2dXfe7cXJjx3rjvfe8cPRoLgIDXWtKCb1e3yxz2lwwv66POXZtzK9rY35dG/Pr2phf1+as+Q0JCalyW41dJNq3b49Lly4hMzMTFosFKSkp6NOnj8M+2dnZWLZsGZ544gmHi+n1eqSnp6O4uBiSJOHw4cMIDQ2tx624trg4A0RRwObNHOyRiIiIiIiInEuNLRiUSiWmTZuGJUuWQBRFDB06FGFhYdi+fTsAIDY2FvHx8SgoKMCaNWvsxyxduhQdO3bEgAED8Oyzz0KpVKJNmzYOrRTIUceOFkRGmpCQ4IF//atQ7nCIiIiIiIiIak2QKhtkoQm4ePGi3CHIYt06Dyxc6IekpExERLjOWAzO2vyHaof5dX3MsWtjfl0b8+vamF/Xxvy6NmfNb726SFDjGjvWCJVKQkKCh9yhEBEREREREdUaCwxNTECAiKgoIzZtcofFdRowEBERERERkYtjgaEJmjDBgMxMJfbu1cgdChEREREREVGtsMDQBEVHG+HrKyI+nrNJEBERERERkXNggaEJ0miAMWMM+PZbLa5fF+QOh4iIiIiIiKhGLDA0UXFxRTAaFfjmG63coRARERERERHViAWGJqp3bzPatLEgPp6zSRAREREREVHTxwJDEyUItlYMKSkanD+vlDscIiIiIiIiomqxwNCETZhgAABs2sTBHomIiIiIiKhpY4GhCWvVyooBA4oRH+8OSZI7GiIiIiIiIqKqscDQxE2YYMDJk2qkpanlDoWIiIiIiIioSiwwNHGjRhmg0Ugc7JGIiIiIiIiaNBYYmjgfHwnDhhmxZYs7TCa5oyEiIiIiIiKqHAsMTiAurghXryqwa5dW7lCIiIiIiIiIKsUCgxO4885i6PVWxMdzNgkiIiIiIiJqmlhgcAIqFTB+vAFJSVrk5Qlyh0NERERERERUAQsMTiIurghms4CtW9mKgYiIiIiIiJoeFhicRNeuFnTpYuZsEkRERERERNQkscDgJATB1orhwAE3nDyplDscIiIiIiIiIgcsMDiR8eMNUCgkJCSwFQMRERERERE1LSwwOJHgYBGDBxdj0yZ3iKLc0RARERERERHdwAKDk4mLM+DcORX27XOTOxQiIiIiIiIiOxYYnMzw4UZ4eoqIj+dsEkRERERERNR0sMDgZDw8JIwcacS2be4wGOSOhoiIiIiIiMiGBQYnFBdXhIICBbZv18odChEREREREREAFhic0sCBJoSEWBAfz9kkiIiIiIiIqGlggcEJKRTA3/9uwO7dGmRmMoVEREREREQkP346dVJxcQaIooDNmznYIxEREREREcmPBQYn1bGjBZGRJiQksJsEERERERERyY8FBicWF1eEP/5Q4+hRldyhEBERERERUTPHAoMTGzvWCJVKYisGIiIiIiIikl2tvvpOS0vDunXrIIoioqKiMG7cOIftP/74IxITEwEAWq0WjzzyCNq0aQMAKCwsxKpVq3Du3DkIgoAZM2agU6dODXsXzVRAgIioKCM2bXLH/Pn5ULEhAxEREREREcmkxo+koihi7dq1WLhwIXQ6HebPn48+ffqgZcuW9n0CAwPx4osvwsvLC7///jtWr16NV155BQCwbt06REZG4umnn4bFYkFxcfGtu5tmaMIEA77/3h1792pw1118bYmIiIiIiEgeNXaRyMjIQHBwMIKCgqBSqTBo0CCkpqY67NO5c2d4eXkBADp27IicnBwAQFFREf7880/cfffdAACVSgVPT8+GvodmLTraCF9fEfHxnE2CiIiIiIiI5FNjC4bc3FzojXDQ9wAAIABJREFUdDr7sk6nQ3p6epX779y5E7169QIAZGZmwsfHB++99x7OnDmDdu3aYerUqdBqtQ0QOgGARgOMGWPAl1+6o6BAgJeXJHdIRERERERE1AzVWGCQpIofWAVBqHTfI0eOYNeuXVi8eDEAwGq14tSpU5g2bRo6duyIdevWYcuWLZg8eXKFY5OTk5GcnAwAWLp0KfR6fZ1upDl75BEBn36qwJ49LfDgg6Lc4VRKpVIxpy6M+XV9zLFrY35dG/Pr2phf18b8ujZXzG+NBQadTmfv8gAAOTk58Pf3r7DfmTNn8MEHH2D+/Pnw9va2H6vT6dCxY0cAwIABA7Bly5ZKrxMdHY3o6Gj7cnZ2dt3upBlr3x5o0yYQ69ZZcc89OTUfIAO9Xs+cujDm1/Uxx66N+XVtzK9rY35dG/Pr2pw1vyEhIVVuq3EMhvbt2+PSpUvIzMyExWJBSkoK+vTp47BPdnY2li1bhieeeMLhYn5+ftDpdLh48SIA4PDhww6DQ1LDEAQgLq4IKSkanD+vlDscIiIiIiIiaoZqbMGgVCoxbdo0LFmyBKIoYujQoQgLC8P27dsBALGxsYiPj0dBQQHWrFljP2bp0qUAgGnTpuHtt9+GxWJBYGAgZs6ceQtvp/maMMGAZct8sGmTO2bNKpA7HCIiIiIiImpmBKmyQRaagNJWD1R7EybokJWlwA8/ZKGKYTJk46zNf6h2mF/Xxxy7NubXtTG/ro35dW3Mr2tz1vzWq4sEOY8JEww4eVKNtDS13KEQEdH/b+/uo6Oq7zyOf+7MZB7ynEwggQjlKdBSWsSGsosCIiFapRWQ07N6qm1dtnuWspxtdz0la7fLsWJpxaXbVo+6cLDL7nbVCEVUlFJQEKxQHrSg5Ull9fAQk0AgZPIwM3f/uMxMJpmQkAcmc/N+nZMzd+793clv+HoT55Pf73cBAAAGGAIGG5kzJyCPx1RlZXqyuwIAAAAAGGAIGGwkO9vUrbc2auNGr5qbk90bAAAAAMBAQsBgMwsWNOjcOae2b/cmuysAAAAAgAGEgMFmZsxoUkFBSJWVvmR3BQAAAAAwgBAw2IzLJc2bF9DvfufVuXP97FYSAAAAAADbImCwoQULGtTSYujFFxnFAAAAAAC4NggYbOjznw/qs59t4W4SAAAAAIBrhoDBhgzDGsWwf79bJ044k90dAAAAAMAAQMBgU/PmBeRwmHrhBUYxAAAAAAD6HgGDTRUVhTVtWpPWr/cpHE52bwAAAAAAdkfAYGMLFgT08ccu7dnjTnZXAAAAAAA2R8BgY7fd1qiMjLAqK7mbBAAAAACgbxEw2Fh6uqk77mjUpk0+BQLJ7g0AAAAAwM4IGGzurrsaVF/v0JYt3mR3BQAAAABgYwQMNjd1arOGDg2qspK7SQAAAAAA+g4Bg805HNL8+QG9/rpHVVWUGwAAAADQN/jEOQAsWBBQOGzot79lsUcAAAAAQN8gYBgASkqCuv76ZqZJAAAAAAD6DAHDALFgQYMOH07Te++5kt0VAAAAAIANETAMEHfe2SiXy9QLLzCKAQAAAADQ+wgYBoj8/LBmzWrU+vU+BYPJ7g0AAAAAwG4IGAaQu+4KqKrKqTff9CS7KwAAAAAAmyFgGEDKyhqVkxNWZSV3kwAAAAAA9C4ChgHE45G+9rWANm/2qr7eSHZ3AAAAAAA2QsAwwCxY0KDGRodeftmb7K4AAAAAAGyEgGGA+dKXWjRiRFCVldxNAgAAAADQewgYBhjDsEYx7N7t0SefOJPdHQAAAACATRAwDEB33RWQJK1fz2KPAAAAAIDeQcAwAA0fHtKUKU2qrPTJNJPdGwAAAACAHRAwDFALFgR04kSaDh5MS3ZXAAAAAAA2QMAwQM2ZE5DHY7LYIwAAAACgV7i60ujgwYNau3atwuGwZs2apblz58Yd37lzpzZu3ChJ8nq9WrhwoUaMGBE9Hg6HtXTpUuXn52vp0qW913t0W3a2qVtvbdTGjV7967/Wye1Odo8AAAAAAKms0xEM4XBYa9as0T//8z9r1apV2rVrlz755JO4NoMHD9ayZcu0cuVK3XXXXXr66afjjr/yyisqLi7u3Z6jxxYsaNC5c05t3+5NdlcAAAAAACmu04Dh+PHjKioqUmFhoVwul6ZOnaq9e/fGtRk3bpwyMzMlSSUlJaqpqYkeq6mp0f79+zVr1qxe7jp6asaMJhUUhFRZyd0kAAAAAAA902nAUFtbK7/fH33u9/tVW1vbYftt27Zp0qRJ0efPPPOMvvGNb8gwjB52Fb3N5ZLmzQvod7/z6tw56gMAAAAA6L5O12AwE9zHsKOw4NChQ9q+fbseeughSdK+ffuUk5OjUaNG6fDhw1f8Plu3btXWrVslSStWrFBBQUGnnUfP/c3fGPqP/zC0bdsg/e3fhvvs+7hcLmpqY9TX/qixvVFfe6O+9kZ97Y362psd69tpwOD3+9tNecjLy2vX7uTJk3rqqadUUVGhrKwsSdKRI0f0xz/+UQcOHFBzc7MCgYB+8YtfaMmSJe3OLysrU1lZWfR5dXV1t94Qrs7QodJnPztIq1ebmj27RtnZ7QOl3lBQUEBNbYz62h81tjfqa2/U196or71RX3tL1foOHTq0w2OdBgyjR4/W6dOnVVVVpfz8fO3evbtdQFBdXa2VK1dq8eLFcd/snnvu0T333CNJOnz4sDZt2pQwXEDyGIb0zW9eUkVFrq6/vkhlZY2aPz+gmTMb5fEku3cAAAAAgFTRacDgdDp1//33a/ny5QqHw5o5c6aGDRumLVu2SJLKy8tVWVmp+vp6rV69OnrOihUr+rbn6DX33tugCRNatGGDTxs3+vTyyz7l5oZ1xx0BzZ8f0Je/3CxHp6t1AAAAAAAGMsNMtMhCP3Dq1Klkd2FACgalnTs9Wr/ep1df9aqhwaHi4qDmzg1o3ryAPve5YLdeN1WH/6BrqK/9UWN7o772Rn3tjfraG/W1t1Stb4+mSGBgcbmkmTObNHNmkxoaDL32mlfr1/v05JOZevzxLH3ucy2aPz+gO+9sUHFx3y0KCQAAAABILQx8R4fS003NmxfQunW12r//rB5++Lx8PlPLl2drypRCLVjg1//8T7rq6rjFJQAAAAAMdAQM6JKCgrC+/e0GbdpUrV27zuof//GiqqoceuABa3HIhQvz9PLLXjU2JrunAAAAAIBkYIoErtqIESF973v1+od/qNe776Zp/XqfXnzRp82bfcrOthaHnDcvoL/8SxaHBAAAAICBgoAB3WYY0sSJLZo4sUX/8i8XtHu3Ry+8YIUNv/lNhoqKQpcXh2zQjBnJ7i0AAAAAoC/x92X0CpdLmj69Sf/+7+f1zjtn9cQTtfrCF1q0enWGbr11sG64waVf/jJTn3ziTHZXAQAAAAB9gIABvc7nM3XnnY165plaHThwVo88cl65udKKFdbikPPm+bVuXbrOnWNxSAAAAACwCwIG9Kn8/LC++c0Gbd8e1FtvndUPfnBB5845tHRpriZNKtK3v52nF1/0KhBIdk8BAAAAAD3BGgy4ZoYPD2nJknr9/d/X6/Bhl9avT9fGjT5t2eJTZmZYt9/eqHnzGnTjjc1yMpMCAAAAAFIKAQOuOcOQJkwIasKEC3rwwQvavdutDRvS9corXj33XLoKC0P62tcCuuuugCZMaJHBTAoAAAAA6PeYIoGkcjqladOa9W//dl4HDpzRU0/VatKkZj3zTIZuu22Qbr55kH7+80ydPMmQBgAAAADozwgY0G/4fNKcOY1as+acDhw4o5/+9LwKCsJ69NFsTZ1aqDvvLNAzz6Srtpb/bAEAAACgv+GTGvqlvDxT3/hGg154oUZvv31WFRUXVF9v6MEHczVpUqHuuy9fv/2tT4EA8ycAAAAAoD9gDQb0e9ddF9LixfVavLhe773n0oYNPm3YkK7f/96rjIywbrutUfPnB3TjjU1KS0t2bwEAAABgYCJgQEoZPz6o8eMvqqLiov7wB7c2bPDppZd8euGFdOXmhvWVrwQ0Z04jYQMAAAAAXGMEDEhJDoc0dWqzpk5t1sMP1+n117166SWvNm3y6Te/yVBubli33WaFDTfdRNgAAAAAAH2NgAEpz+ORbr21Ubfe2qjGRmnHDo82bfLp5Zd9+t//tcKGW29t1Jw5Ad10U5Pc7mT3GAAAAADsh4ABtuL1SuXlTSovb1JTk/TGG1bY8MorXj37bLpycmJhw7RphA0AAAAA0FsIGGBbHk/7sOGll3zavNmr556zwobycitsmD6dsAEAAAAAeoKAAQNC27Bhxw4rbHjtNa+efz5d2dnxYYPHk+weAwAAAEBqIWDAgOPxSLNnN2n2bCts2LkzFjZUVlphw+zZjfrqVwkbAAAAAKCrCBgwoHk8UllZk8rKmtTcHB82vPBCurKyYiMbZswgbAAAAACAjhAwAJe53dKsWU2aNcsKG958s33Y0Hpkg9eb7B4DAAAAQP9BwAAk4HZLt9zSpFtuscKGXbusu1G89ppX69enKzMzMrKhUTNmNBI2AAAAABjwCBiATrjd0syZTZo5s0ktLZGRDV69+qovGjbMnm2FDTffTNgAAAAAYGAiYACuQlpaLGxYsaJOu3ZZYcPmzT5t2JCujIz4sMHnS3aPAQAAAODaIGAAuiktTbr55ibdfHOTfvKTOu3eHQkbvPrtb62woazMChtmziRsAAAAAGBvBAxAL0hLk2bMaNKMGU165JE6vfWWFTa88opXGzemKz09rLKyJn31qwHCBgAAAAC2RMAA9LK0NGn69CZNn26FDbt3u/XSSz5t3uzViy/6omHDnDkB3XJLk3w+M9ldBgAAAIAeI2AA+pDLJU2f3qzp05sThg0+nxU23H57QDfe2Cy/P5zsLgMAAABAtxAwANdI27DhrbdiYcOmTdaciTFjWjRlSrOmTGnWX/xFs4qLQ0nuNQAAAAB0TZcChoMHD2rt2rUKh8OaNWuW5s6dG3d8586d2rhxoyTJ6/Vq4cKFGjFihKqrq/X444/r/PnzMgxDZWVluv3223v/XQApxuWSpk1r1rRpzVq+vE4HDrj19tvW14sv+vTf/50hSSouDkYDhylTmjVmTFCGkeTOAwAAAEACnQYM4XBYa9as0Q9/+EP5/X5VVFSotLRU1113XbTN4MGDtWzZMmVmZurAgQN6+umn9cgjj8jpdOree+/VqFGjFAgEtHTpUn3xi1+MOxcY6FwuafLkZk2e3KzFi6VQSHr/fZfeftujt992a+dOj9avT5ck+f0hffnLscBh/PgWuRiHBAAAAKAf6PSjyfHjx1VUVKTCwkJJ0tSpU7V37964kGDcuHHR7ZKSEtXU1EiS8vLylJeXJ0ny+XwqLi5WbW0tAQNwBU6nNGFCUBMmBPXXf31Jpil98IFTe/Z49Ic/uLVnj1ubN1tTKjIzwyotbdaXv2xNqZg4sVleb5LfAAAAAIABqdOAoba2Vn6/P/rc7/fr2LFjHbbftm2bJk2a1G5/VVWVPvzwQ40ZM6abXQUGJsOQRo8OafToBt19d4Mk6dQph/bssUY47Nnj1s9+li1JcrtNTZrUHB3lUFrarKws7lIBAAAAoO91GjCYZvsPJ0YHk8APHTqk7du366GHHorb39jYqMcee0zf+ta3lJ6envDcrVu3auvWrZKkFStWqKCgoNPOI3W4XC5q2osKCqQvflFauFCSTNXUNGv3bkNvvunQrl1peuIJt375S0MOh6mJE03ddJOpm24K68YbTQ0a1Pv9ob72R43tjfraG/W1N+prb9TX3uxYX8NMlCC0cvToUT3//PN68MEHJUkbNmyQJM2bNy+u3cmTJ7Vy5UpVVFRo6NCh0f3BYFA//elPNXHiRM2ZM6fLHTt16lSX26L/KygoUHV1dbK7MWBcumRo37606LSKAwfcamy0gsHWd6qYMqVZ113X8ztVUF/7o8b2Rn3tjfraG/W1N+prb6la39af99vqdATD6NGjdfr0aVVVVSk/P1+7d+/WkiVL4tpUV1dr5cqVWrx4cdw3M01TTz75pIqLi68qXADQMxkZZvSWmJLU3Cy9+25adOHITZva36kiso4Dd6oAAAAA0B2dBgxOp1P333+/li9frnA4rJkzZ2rYsGHasmWLJKm8vFyVlZWqr6/X6tWro+esWLFCR44c0Y4dOzR8+HA98MADkqS7775bN9xwQx++JQBtud1SaWmLSktb9N3vWneq+POfXdqzx60//MGjN9+M3akiPz8UDRymTGnW5z/PnSoAAAAAdK7TKRLJwhQJe0nV4T8DhWlKH33k1Ntvu6OjHE6etFKFjAzrThWRKRXXX9/+ThXU1/6osb1RX3ujvvZGfe2N+tpbqta3R1MkANifYUgjR4Y0cmRAf/VXAUnS6dMO7dljBQ5t71Rx/fWxKRWlpc2y2do0AAAAALqBgAFAQkOGhHXnnY26885GSdK5c4b27nVHF4588slM/epX1p0qvvAFUyUluRo7NqiSkhaNHRvUsGEhOZ1JfhMAAAAArhkCBgBdkpdnqry8SeXlTZKkhobYnSrefTdDb77pUWVl7Da0Xq+p0aODGjeuRSUlwWj48JnPhFjTAQAAALAh/jcfQLekp5uaNq1Z06Y1q6DAo+rqal24YOjYMZeOHXPp6NE0HTtmLSQZWUBSsqZYjB4dvBw6WOHDuHFBjRgRVFpaEt8QAAAAgB4hYADQa7KzTX3pSy360pdaJAWi+y9dMi6HDrHw4Z130rRpk1emad0T0+UyNWpUMG60w9ixQY0aFZTHk6Q3BAAAAKDLCBgA9LmMDFPXX9+i669vidsfCBg6ccKpo0fTdPSoFUC8916aNm/2Khy2ggen09RnPhOKG+1QUtKi0aOD8vmS8W4AAAAAJELAACBpfD5TEyYENWFCMG5/Y6P0wQex0Q6RkQ9bt3oVDFrBg2FYwUPrqRZjxwY1ZkxQGRn98u67AAAAgK0RMADod7xeafz4oMaPD0pqjO5vbpY+/DB+qsWxYy69/rpHLS1GtN2wYbGpFpHwoaQkqKwsggcAAACgrxAwAEgZbrc0bpw1TaK1lhbp5Emnjh1L05EjsfBh1y6PmppiwcOQIaG40Q6RtR5ycwkeAAAAgJ4iYACQ8tLSpDFjQhozJqSvfCW2PxSS/u//nHFTLY4edem//itdjY2OaLtBg0IqLg6psDCkoqLw5Udru6jI2p+TY8owEnxzAAAAAJIIGADYmNMpjRwZ0siRIZWXN0X3h8PSJ584o1Mtjh936fRpp06edOntt506f97R7rW83nA0cLBCh1j4MGSIFUoUFobk9V7LdwgAAAD0HwQMAAYch0MaPjyk4cNDKitranc8EJDOnnXq7Fmnzpxx6MwZp86ccersWWv74EG3zpxxqrGx/ZCG3NywhgwJRUdBRIKIyIiIwsKQCgrCcjqvxTsFAAAArh0CBgBow+eTRowIacSIUIdtTFOqqzMuBw9WEHH6dGz77Fmn3n8/TZ9+6ojecjPC6TQ1eHDi0RCtp2ZkZTEtAwAAAKmDgAEAusEwpNxcU7m5QX32s8EO2wWD0qefOi4HD7EREZEg4oMPXNq926m6uvbTMny+xNMyWocQgweH5PH05TsFAAAAuoaAAQD6kMslDRkS1pAhYUktHbYLBIx24UPrqRn79rl19qwz7q4YEXl5octhR1jZ2WHl5JiXH2Pb2dlh5ea2305L68M3DwAAgAGFgAEA+gGfz4wuSNkR05TOnTOioyHOno1Ny6irc+jCBUN1dQ59/HFsu6XlynMs0tPDys42L4cR1rYVQMRvX3edIcNwRwOMnJywMjNNOdoPvAAAAMAARcAAACnCMKT8fFP5+UF97nMdT8uIME2psdFQXZ1xOYBwtNq2HiPbFy44dP68Q2fOOHTkiEsXLlj7TbN1QFHQpj9mNJywRkbERlG0Di1iIypibXNyTHm9rDEBAABgJwQMAGBThmGNjPD5TBUVha/6/HBYunjRCh8cjnx99FFdNHg4f96RcPvECVc0tGhouPLwBrfbjIYR2dlhZWWZysoKR7dzclrvS/zodnf3XwcAAAC9jYABAJCQw6HLow5CKigwVVzcfFXnNzdLFy864kZQnD9vXA4jYvvr6hzRIOPMGZcuXuxaQCFJXq8VNGRlJQ4p2j4mCilYJBMAAKB3EDAAAPqE2y35/WH5/ZLU8doSHQkGrREUkcDh4sVYEBF7jD9WV3f1IYXH0z6kSBxIxO+LjL4gpAAAALAQMAAA+iWXS8rLM5WXd/XhRER3QooLFxyqqnJF21y61HlIkZZmKiPDVHp6WBkZkW1TmZnh6HZkf0ZG+PKx9ue0buN2izUqAABASiFgAADYVm+EFKFQbC2KjkKKhgZDly5ZYcSlS4YaGgzV1xv65BNXq2NdG1ER67vZKpyIDyoSBReRoKKj4CI9PSyvl9ACAAD0HQIGAACuwOmUcnNN5eZ2P6SICIelQMAKG+rrjcvhg6NVABF73vZ4JKg4c8ahS5dc0XO6MsIi9l7ahxbWc5dMM18ulymXy3rPLpcpp9ManWE9t853uRRtF2lz9cdi+5xOU2lprdu0b9/2WFqauEUqAAD9EAEDAADXiMOh6If6wYN75zXDYet2pLHAwRopUV9vJAwuYiMsWo+2kBobHQoGDYVC1tSSYNCIPkb2hUKGWlqsx2BQCoeTNxzCMGLhQ3q6GV0PI7KGRkd3Hom1i20zsgMAgN5BwAAAQApzOKT0dOtD9qBB3XuNgoICVVdXX/V54bDaBRKR8CHy2DqQaP3Y0qKE7UMhqaUlEmrEH4s9jw9ALl0y4qatfPSRq9V0ls6HOrjdXV3oM7bgZ9t9Xm93/uUBALAXAgYAANAtDof1lZYmSeblveYVzrj2QiGpvj5+oc+2j23X1LhwwaEPPogt9Flf3/2QIlE40Ta4sEZQmHI4rJEUkX/XyL7WX4n3XYN/SAAAuoCAAQAA2JbTKeXkmMrJ6dlCn1cKKeLvShLZf/UhRU84HGaH4YTTacgwitqFE1Z7M+557DXMNu063udySV6vGffl8ZjyetVqu+2xyJcS7vd4THk8hCcAkGoIGAAAAK6gt0KKtrdMjTy2tFjrWYTDin5J7feZZuf7rOeSacb2eTw+NTQEErZLfG5sf6xdon2x9Tmqqx1qajLU2Gh9td7uLsOIDyoShRCRkCLRfp+v46CjbciRlmbK7bZCDbfbWqAUAHD1CBgAAAD6WG/ejeRqFRS4VV194Zp/X8kKI5qalDB4iG3Hjrfe3/p46/MiX/X1DtXUxM5v3SYY7NnQB6czPnCwvqwgI/FzXW6f6HnsNdo/T3wsLa3tMUZzAEgNBAwAAADoE4ah6AiCa7k+RzCohAFGooCjqclq29wc+Wr9XGpuNjp4LtXXO+KeR16jqcnaDoV6LxWIjLJoG0x4vU6FQoOiU1wMIzZdJrJPaj0FxmzVNna8dfvIa0Rep/X5keMdv378+YlfP75NhGkm3raeG1c4dqXzOj7WvdeIr6nDYY2WiYyGiWzH9nW+7fNZt98lRIIdEDAAAADAVlwuyeWybgmbTKGQ4gKHttvtn6uDoKN98BHZdjicamoKyjStD7/WY0dfRtxUGCl2LBSypr20bhc5Hmnfte8Re53Wrx//OvHHO/pg3Xa/YZhXOHal87rW7srfO3E/QqH2o2u6w+FIHEBkZbnkdPq7HVy032eNvHH07bIwGMAIGAAAAIA+4HRaf9H2+aS+GsFh3Wb2XJ+8Nq5eOGyFP4GAFAhYgUPksSvbbfdF1m85d84RHY3Tum3bERVdFQke3G4zpUdOREblOJ3W9WYtbGstPhvZbr0/0i7R/iu3aX+s9X6Hwwo2E+2/0rm5uYZKSyW3O9n/kr2nSwHDwYMHtXbtWoXDYc2aNUtz586NO75z505t3LhRkuT1erVw4UKNGDGiS+cCAAAAgB04HL0bKlkBUnXCY6YpNTerW8FFZPpQc3MKpwuyAp1QyLg8Aie2bX21328FQFIw6Li83zrWerv1+Z21CYd7/u936JAht7t/3eK5JzoNGMLhsNasWaMf/vCH8vv9qqioUGlpqa677rpom8GDB2vZsmXKzMzUgQMH9PTTT+uRRx7p0rkAAAAAgKtjGJLHY015yMmxzwfUVBKZ+tM21IiED223g8H4/dnZecrKslftOg0Yjh8/rqKiIhUWFkqSpk6dqr1798aFBOPGjYtul5SUqKampsvnAgAAAACQagxD0akPltZhQefBQUGBqQ4GqKSsTpf3qK2tld/vjz73+/2qra3tsP22bds0adKkbp0LAAAAAABSU6cjGMwE93MxOlgJ5NChQ9q+fbseeuihqz5369at2rp1qyRpxYoVKigo6KxrSCEul4ua2hj1tT9qbG/U196or71RX3ujvvZmx/p2GjD4/f7olAdJqqmpUV5eXrt2J0+e1FNPPaWKigplZWVd1bmSVFZWprKysujzjhYzQWq60gI1SH3U1/6osb1RX3ujvvZGfe2N+tpbqtZ36NChHR7rdIrE6NGjdfr0aVVVVSkYDGr37t0qLS2Na1NdXa2VK1dq8eLFcd+sK+cCAAAAAIDU1+kIBqfTqfvvv1/Lly9XOBzWzJkzNWzYMG3ZskWSVF5ersrKStXX12v16tXRc1asWNHhuQAAAAAAwF4MM9FCCf3AqVOnkt0F9KJUHf6DrqG+9keN7Y362hv1tTfqa2/U195Stb49miIBAAAAAADQGQIGAAAAAADQYwQMAAAAAACgxwgYAAAAAABAj/XbRR4BAAAAAEDqYAQDromlS5cmuwvoQ9TX/qixvVFfe6O+9kZ97Y362psd60vAAAAAAAAAeoyAAQAAAAAA9Jhz2bJly5LdCQwMo0aNSnYX0Ieor/1RY3ujvvZGfe2N+tob9bU3u9WXRR4BAAAAAECPMUUCAAAAAAD0mCvZHYB9VFdX6/HHH9f58+dZva5AAAAGz0lEQVRlGIbKysp0++23x7U5fPiwfvazn2nw4MGSpClTpmjBggXJ6C664bvf/a68Xq8cDoecTqdWrFgRd9w0Ta1du1YHDhyQx+PRokWLbDfsy65OnTqlVatWRZ9XVVXp61//uu64447oPq7f1PPEE09o//79ysnJ0WOPPSZJqq+v16pVq/Tpp59q0KBB+t73vqfMzMx25x48eFBr165VOBzWrFmzNHfu3GvdfXQiUX3XrVunffv2yeVyqbCwUIsWLVJGRka7czv7eY7kS1Tf5557Tr///e+VnZ0tSbr77rt1ww03tDuX67f/S1TfVatW6dSpU5KkhoYGpaen69FHH213Ltdv/9fR56IB8TvYBHpJbW2teeLECdM0TbOhocFcsmSJ+fHHH8e1OXTokPmTn/wkGd1DL1i0aJFZV1fX4fF9+/aZy5cvN8PhsHnkyBGzoqLiGvYOvSUUCpkLFy40q6qq4vZz/aaew4cPmydOnDC///3vR/etW7fO3LBhg2maprlhwwZz3bp17c4LhULm4sWLzTNnzpgtLS3mP/3TP7X7eY7kS1TfgwcPmsFg0DRNq9aJ6muanf88R/Ilqu+zzz5rbty48Yrncf2mhkT1be3Xv/61+fzzzyc8xvXb/3X0uWgg/A5migR6TV5eXvSv1T6fT8XFxaqtrU1yr3At/fGPf9T06dNlGIbGjh2rS5cu6dy5c8nuFq7Sn/70JxUVFWnQoEHJ7gp6aPz48e3+MrJ3717NmDFDkjRjxgzt3bu33XnHjx9XUVGRCgsL5XK5NHXq1ITtkFyJ6jtx4kQ5nU5J0tixY/k9nMIS1bcruH5Tw5Xqa5qm3nrrLd14443XuFfoLR19LhoIv4OZIoE+UVVVpQ8//FBjxoxpd+zo0aN64IEHlJeXp3vvvVfDhg1LQg/RXcuXL5ckzZ49W2VlZXHHamtrVVBQEH3u9/tVW1urvLy8a9pH9MyuXbs6/J8art/UV1dXF70m8/LydOHChXZtamtr5ff7o8/9fr+OHTt2zfqI3rFt2zZNnTq1w+NX+nmO/uu1117Tjh07NGrUKN13333tPqRy/aa+999/Xzk5ORoyZEiHbbh+U0frz0UD4XcwAQN6XWNjox577DF961vfUnp6etyxkSNH6oknnpDX69X+/fv16KOP6he/+EWSeoqr9eMf/1j5+fmqq6vTww8/rKFDh2r8+PHR42aCm9IYhnEtu4geCgaD2rdvn+655552x7h+Bw6u5dS3fv16OZ1OTZs2LeHxzn6eo38qLy+Prn3z7LPP6j//8z+1aNGiuDZcv6nvSkG/xPWbSq70uagjqX4NM0UCvSoYDOqxxx7TtGnTNGXKlHbH09PT5fV6JUk33HCDQqFQwuQO/VN+fr4kKScnR5MnT9bx48fjjvv9flVXV0ef19TUMHohxRw4cEAjR45Ubm5uu2Ncv/aQk5MTnbp07ty56GJxrfn9ftXU1ESfcy2nltdff1379u3TkiVLOvyf0s5+nqN/ys3NlcPhkMPh0KxZs3TixIl2bbh+U1soFNKePXuuOPqI6zc1JPpcNBB+BxMwoNeYpqknn3xSxcXFmjNnTsI258+fj6Zyx48fVzgcVlZW1rXsJrqpsbFRgUAguv3uu+9q+PDhcW1KS0u1Y8cOmaapo0ePKj09PaV+IOLKfzXh+rWH0tJSvfHGG5KkN954Q5MnT27XZvTo0Tp9+rSqqqoUDAa1e/dulZaWXuuuohsOHjyojRs36gc/+IE8Hk/CNl35eY7+qfW6Rnv27Ek4TY3rN7X96U9/0tChQ+OGyLfG9ZsaOvpcNBB+BxtmojEYQDf8+c9/1o9+9CMNHz48+heTu+++O/oX7fLycr366qvasmWLnE6n3G637rvvPo0bNy6Z3UYXnT17VitXrpRkpes33XST5s+fry1btkiy6muaptasWaN33nlHbrdbixYt0ujRo5PZbVyFpqYm/d3f/Z1+9atfRYfxta4v12/q+fnPf6733ntPFy9eVE5Ojr7+9a9r8uTJWrVqlaqrq1VQUKDvf//7yszMVG1trZ566ilVVFRIkvbv369f//rXCofDmjlzpubPn5/kd4O2EtV3w4YNCgaD0Xn5JSUl+s53vhNX345+nqN/SVTfw4cP66OPPpJhGBo0aJC+853vKC8vj+s3BSWq7y233KLHH39cJSUlKi8vj7bl+k09HX0uKikpsf3vYAIGAAAAAADQY0yRAAAAAAAAPUbAAAAAAAAAeoyAAQAAAAAA9BgBAwAAAAAA6DECBgAAAAAA0GMEDAAAAAAAoMcIGAAAAAAAQI8RMAAAAAAAgB77fwd4u+2OErTFAAAAAElFTkSuQmCC\n",
       "text/plain": [
-       "<Figure size 1296x360 with 3 Axes>"
+       "<Figure size 1296x360 with 1 Axes>"
       ]
      },
      "metadata": {},
@@ -1714,33 +1765,17 @@
     }
    ],
    "source": [
-    "plot_history(history)"
+    "plot_history(model_pipe.named_steps['blender'].history)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.376277,
-     "end_time": "2020-11-13T16:38:15.235063",
+     "duration": 0.431924,
+     "end_time": "2020-11-14T07:30:15.808024",
      "exception": false,
-     "start_time": "2020-11-13T16:38:14.858786",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "## The f1score and accuracy seem not to increase after the 5th epoch. Our best epoch for our blender is 5"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "papermill": {
-     "duration": 0.37722,
-     "end_time": "2020-11-13T16:38:15.999592",
-     "exception": false,
-     "start_time": "2020-11-13T16:38:15.622372",
+     "start_time": "2020-11-14T07:30:15.376100",
      "status": "completed"
     },
     "tags": []
@@ -1754,10 +1789,10 @@
    "execution_count": null,
    "metadata": {
     "papermill": {
-     "duration": 0.378342,
-     "end_time": "2020-11-13T16:38:16.752933",
+     "duration": 0.531268,
+     "end_time": "2020-11-14T07:30:16.772316",
      "exception": false,
-     "start_time": "2020-11-13T16:38:16.374591",
+     "start_time": "2020-11-14T07:30:16.241048",
      "status": "completed"
     },
     "tags": []
@@ -1770,24 +1805,24 @@
    "execution_count": 50,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-13T16:38:17.513513Z",
-     "iopub.status.busy": "2020-11-13T16:38:17.512394Z",
-     "iopub.status.idle": "2020-11-13T16:38:22.198144Z",
-     "shell.execute_reply": "2020-11-13T16:38:22.199328Z"
+     "iopub.execute_input": "2020-11-14T07:30:17.746857Z",
+     "iopub.status.busy": "2020-11-14T07:30:17.745825Z",
+     "iopub.status.idle": "2020-11-14T07:30:17.888017Z",
+     "shell.execute_reply": "2020-11-14T07:30:17.887288Z"
     },
     "papermill": {
-     "duration": 5.070542,
-     "end_time": "2020-11-13T16:38:22.199517",
+     "duration": 0.589637,
+     "end_time": "2020-11-14T07:30:17.888145",
      "exception": false,
-     "start_time": "2020-11-13T16:38:17.128975",
+     "start_time": "2020-11-14T07:30:17.298508",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [],
    "source": [
-    "X_train, X_test, y_train, y_test = train_test_split(Xtt, ytt, test_size=0.25, \\\n",
-    "                                                    stratify=ytt, random_state=1)"
+    "X_train, X_test, y_train, y_test = train_test_split(X_prep, encoded_labels, test_size=0.25, \\\n",
+    "                                                    stratify=encoded_labels, random_state=1)"
    ]
   },
   {
@@ -1795,23 +1830,23 @@
    "execution_count": 51,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-13T16:38:23.063850Z",
-     "iopub.status.busy": "2020-11-13T16:38:23.062752Z",
-     "iopub.status.idle": "2020-11-13T16:38:23.077200Z",
-     "shell.execute_reply": "2020-11-13T16:38:23.077803Z"
+     "iopub.execute_input": "2020-11-14T07:30:18.751100Z",
+     "iopub.status.busy": "2020-11-14T07:30:18.749158Z",
+     "iopub.status.idle": "2020-11-14T07:30:18.751921Z",
+     "shell.execute_reply": "2020-11-14T07:30:18.752468Z"
     },
     "papermill": {
-     "duration": 0.437429,
-     "end_time": "2020-11-13T16:38:23.077950",
+     "duration": 0.435443,
+     "end_time": "2020-11-14T07:30:18.752603",
      "exception": false,
-     "start_time": "2020-11-13T16:38:22.640521",
+     "start_time": "2020-11-14T07:30:18.317160",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [],
    "source": [
-    "model2 = build_blender()"
+    "cnn_model2 = NLPModel(build_cnn_model, 'cnn_model', epochs=7)"
    ]
   },
   {
@@ -1819,53 +1854,23 @@
    "execution_count": 52,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-13T16:38:23.862839Z",
-     "iopub.status.busy": "2020-11-13T16:38:23.861839Z",
-     "iopub.status.idle": "2020-11-13T16:38:36.745120Z",
-     "shell.execute_reply": "2020-11-13T16:38:36.744629Z"
+     "iopub.execute_input": "2020-11-14T07:30:19.732548Z",
+     "iopub.status.busy": "2020-11-14T07:30:19.731655Z",
+     "iopub.status.idle": "2020-11-14T07:30:19.734296Z",
+     "shell.execute_reply": "2020-11-14T07:30:19.734883Z"
     },
     "papermill": {
-     "duration": 13.281667,
-     "end_time": "2020-11-13T16:38:36.745227",
+     "duration": 0.542858,
+     "end_time": "2020-11-14T07:30:19.735029",
      "exception": false,
-     "start_time": "2020-11-13T16:38:23.463560",
+     "start_time": "2020-11-14T07:30:19.192171",
      "status": "completed"
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 1/5\n",
-      "936/936 [==============================] - 2s 3ms/step - loss: 1.8685 - accuracy: 0.7407 - multi_class_fbeta: 0.7209\n",
-      "Epoch 2/5\n",
-      "936/936 [==============================] - 3s 3ms/step - loss: 0.7045 - accuracy: 0.9020 - multi_class_fbeta: 0.9031\n",
-      "Epoch 3/5\n",
-      "936/936 [==============================] - 3s 3ms/step - loss: 0.4401 - accuracy: 0.9042 - multi_class_fbeta: 0.9056\n",
-      "Epoch 4/5\n",
-      "936/936 [==============================] - 2s 3ms/step - loss: 0.3662 - accuracy: 0.9051 - multi_class_fbeta: 0.9064\n",
-      "Epoch 5/5\n",
-      "936/936 [==============================] - 2s 2ms/step - loss: 0.3372 - accuracy: 0.9057 - multi_class_fbeta: 0.9070\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<tensorflow.python.keras.callbacks.History at 0x7fa0a4401a10>"
-      ]
-     },
-     "execution_count": 52,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "model2.fit(X_train, y_train,\n",
-    "                    epochs=5, # using the best epoch from model1\n",
-    "                    verbose=True,\n",
-    "                    batch_size=128)"
+    "lstm_model2 = NLPModel(build_lstm_model, 'lstm_model', epochs=10)"
    ]
   },
   {
@@ -1873,16 +1878,88 @@
    "execution_count": 53,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-11-13T16:38:37.685576Z",
-     "iopub.status.busy": "2020-11-13T16:38:37.684425Z",
-     "iopub.status.idle": "2020-11-13T16:38:39.679386Z",
-     "shell.execute_reply": "2020-11-13T16:38:39.678876Z"
+     "iopub.execute_input": "2020-11-14T07:30:20.924299Z",
+     "iopub.status.busy": "2020-11-14T07:30:20.922555Z",
+     "iopub.status.idle": "2020-11-14T07:30:20.927628Z",
+     "shell.execute_reply": "2020-11-14T07:30:20.928365Z"
     },
     "papermill": {
-     "duration": 2.46994,
-     "end_time": "2020-11-13T16:38:39.679502",
+     "duration": 0.714733,
+     "end_time": "2020-11-14T07:30:20.928566",
      "exception": false,
-     "start_time": "2020-11-13T16:38:37.209562",
+     "start_time": "2020-11-14T07:30:20.213833",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "union2 = FeatureUnion([('cnn_model', cnn_model2), ('lstm_model', lstm_model2)])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-11-14T07:30:21.921894Z",
+     "iopub.status.busy": "2020-11-14T07:30:21.919987Z",
+     "iopub.status.idle": "2020-11-14T07:30:21.922663Z",
+     "shell.execute_reply": "2020-11-14T07:30:21.923155Z"
+    },
+    "papermill": {
+     "duration": 0.482227,
+     "end_time": "2020-11-14T07:30:21.923297",
+     "exception": false,
+     "start_time": "2020-11-14T07:30:21.441070",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "model2 = BlenderModel(build_blender, epochs=9) # best epoch from model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-11-14T07:30:23.151735Z",
+     "iopub.status.busy": "2020-11-14T07:30:23.150843Z",
+     "iopub.status.idle": "2020-11-14T07:30:23.157389Z",
+     "shell.execute_reply": "2020-11-14T07:30:23.155872Z"
+    },
+    "papermill": {
+     "duration": 0.794694,
+     "end_time": "2020-11-14T07:30:23.157548",
+     "exception": false,
+     "start_time": "2020-11-14T07:30:22.362854",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "model_pipe2 = Pipeline([('union', union2), ('blender', model2)], verbose=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-11-14T07:30:24.353082Z",
+     "iopub.status.busy": "2020-11-14T07:30:24.327465Z",
+     "iopub.status.idle": "2020-11-14T07:39:59.786859Z",
+     "shell.execute_reply": "2020-11-14T07:39:59.787435Z"
+    },
+    "papermill": {
+     "duration": 575.95371,
+     "end_time": "2020-11-14T07:39:59.787621",
+     "exception": false,
+     "start_time": "2020-11-14T07:30:23.833911",
      "status": "completed"
     },
     "tags": []
@@ -1892,36 +1969,135 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Training Accuracy: 0.9059\n",
-      "Training Fbeta: 0.9071\n",
-      "\n",
-      "Testing Accuracy: 0.9042\n",
-      "Testing Fbeta: 0.9055\n"
+      "Done training Word2Vec for cnn_model                    total: 1.8mins\n",
+      "Done training cnn_model model                           total: 0.7mins\n",
+      "Done training Word2Vec for lstm_model                    total: 1.8mins\n",
+      "Done training lstm_model model                           total: 4.4mins\n",
+      "[Pipeline] ............. (step 1 of 2) Processing union, total= 9.2min\n",
+      "Epoch 1/9\n",
+      "936/936 [==============================] - 2s 3ms/step - loss: 0.3172 - accuracy: 0.9162 - multi_class_fbeta: 0.9159\n",
+      "Epoch 2/9\n",
+      "936/936 [==============================] - 3s 3ms/step - loss: 0.2483 - accuracy: 0.9236 - multi_class_fbeta: 0.9237\n",
+      "Epoch 3/9\n",
+      "936/936 [==============================] - 3s 4ms/step - loss: 0.2401 - accuracy: 0.9240 - multi_class_fbeta: 0.9240\n",
+      "Epoch 4/9\n",
+      "936/936 [==============================] - 3s 3ms/step - loss: 0.2343 - accuracy: 0.9245 - multi_class_fbeta: 0.9247\n",
+      "Epoch 5/9\n",
+      "936/936 [==============================] - 2s 3ms/step - loss: 0.2295 - accuracy: 0.9249 - multi_class_fbeta: 0.9249\n",
+      "Epoch 6/9\n",
+      "936/936 [==============================] - 2s 3ms/step - loss: 0.2268 - accuracy: 0.9252 - multi_class_fbeta: 0.9252\n",
+      "Epoch 7/9\n",
+      "936/936 [==============================] - 3s 3ms/step - loss: 0.2233 - accuracy: 0.9254 - multi_class_fbeta: 0.9254\n",
+      "Epoch 8/9\n",
+      "936/936 [==============================] - 2s 3ms/step - loss: 0.2229 - accuracy: 0.9251 - multi_class_fbeta: 0.9251\n",
+      "Epoch 9/9\n",
+      "936/936 [==============================] - 2s 3ms/step - loss: 0.2206 - accuracy: 0.9255 - multi_class_fbeta: 0.9253\n",
+      "[Pipeline] ........... (step 2 of 2) Processing blender, total=  24.1s\n"
      ]
     }
    ],
    "source": [
-    "loss, accuracy, fbeta = model2.evaluate(X_train, y_train, batch_size=128, verbose=False)\n",
-    "print('Training Accuracy: {:.4f}\\nTraining Fbeta: {:.4f}'.format(accuracy, fbeta))\n",
-    "print()\n",
-    "loss, accuracy, fbeta = model2.evaluate(X_test, y_test, batch_size=128, verbose=False)\n",
-    "print('Testing Accuracy: {:.4f}\\nTesting Fbeta: {:.4f}'.format(accuracy, fbeta))"
+    "model_pipe2.fit(X_train, y_train);"
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": 57,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-11-14T07:40:01.033269Z",
+     "iopub.status.busy": "2020-11-14T07:40:01.032151Z",
+     "iopub.status.idle": "2020-11-14T07:40:40.631973Z",
+     "shell.execute_reply": "2020-11-14T07:40:40.623307Z"
+    },
     "papermill": {
-     "duration": 0.455098,
-     "end_time": "2020-11-13T16:38:40.598150",
+     "duration": 40.237156,
+     "end_time": "2020-11-14T07:40:40.632135",
      "exception": false,
-     "start_time": "2020-11-13T16:38:40.143052",
+     "start_time": "2020-11-14T07:40:00.394979",
      "status": "completed"
     },
     "tags": []
    },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "936/936 [==============================] - 1s 1ms/step\n",
+      "312/312 [==============================] - 0s 1ms/step\n"
+     ]
+    }
+   ],
    "source": [
-    "## Our blended model seem to out-perform both CNN and LSTM. It also greatly reduced overfitting."
+    "y_pred_train = model_pipe2.predict(X_train)\n",
+    "y_pred_test = model_pipe2.predict(X_test)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-11-14T07:40:41.892933Z",
+     "iopub.status.busy": "2020-11-14T07:40:41.891939Z",
+     "iopub.status.idle": "2020-11-14T07:40:41.992707Z",
+     "shell.execute_reply": "2020-11-14T07:40:41.992093Z"
+    },
+    "papermill": {
+     "duration": 0.73992,
+     "end_time": "2020-11-14T07:40:41.992833",
+     "exception": false,
+     "start_time": "2020-11-14T07:40:41.252913",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "acc_train = accuracy_score(y_train, y_pred_train)\n",
+    "f1_train = f1_score(y_train, y_pred_train, average='weighted')\n",
+    "\n",
+    "acc_test = accuracy_score(y_test, y_pred_test)\n",
+    "f1_test = f1_score(y_test, y_pred_test, average='weighted')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-11-14T07:40:43.252886Z",
+     "iopub.status.busy": "2020-11-14T07:40:43.252020Z",
+     "iopub.status.idle": "2020-11-14T07:40:43.257130Z",
+     "shell.execute_reply": "2020-11-14T07:40:43.257748Z"
+    },
+    "papermill": {
+     "duration": 0.633239,
+     "end_time": "2020-11-14T07:40:43.257888",
+     "exception": false,
+     "start_time": "2020-11-14T07:40:42.624649",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Training accuracy: 0.9258\n",
+      "Training f1_score: 0.9259\n",
+      "\n",
+      "Testing accuracy: 0.8794\n",
+      "Testing f1_score: 0.8796\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('Training accuracy: {:.4f}\\nTraining f1_score: {:.4f}'.format(acc_train, f1_train))\n",
+    "print()\n",
+    "print('Testing accuracy: {:.4f}\\nTesting f1_score: {:.4f}'.format(acc_test, f1_test))"
    ]
   },
   {
@@ -1929,10 +2105,42 @@
    "execution_count": null,
    "metadata": {
     "papermill": {
-     "duration": 0.457732,
-     "end_time": "2020-11-13T16:38:41.517368",
+     "duration": 0.62442,
+     "end_time": "2020-11-14T07:40:44.517420",
      "exception": false,
-     "start_time": "2020-11-13T16:38:41.059636",
+     "start_time": "2020-11-14T07:40:43.893000",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "papermill": {
+     "duration": 0.633924,
+     "end_time": "2020-11-14T07:40:45.768692",
+     "exception": false,
+     "start_time": "2020-11-14T07:40:45.134768",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Our blended model seem to slightly perform better both CNN and LSTM whose f1_scores for the testting set are 0.85 and 0.876 repectively. Improved the LSTM's f1_score by 0.03."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "papermill": {
+     "duration": 0.649227,
+     "end_time": "2020-11-14T07:40:47.048247",
+     "exception": false,
+     "start_time": "2020-11-14T07:40:46.399020",
      "status": "completed"
     },
     "tags": []
@@ -1960,14 +2168,14 @@
    "version": "3.7.7"
   },
   "papermill": {
-   "duration": 735.382968,
-   "end_time": "2020-11-13T16:38:43.349373",
+   "duration": 1484.916647,
+   "end_time": "2020-11-14T07:40:49.231394",
    "environment_variables": {},
    "exception": null,
    "input_path": "__notebook__.ipynb",
    "output_path": "__notebook__.ipynb",
    "parameters": {},
-   "start_time": "2020-11-13T16:26:27.966405",
+   "start_time": "2020-11-14T07:16:04.314747",
    "version": "2.1.0"
   }
  },


### PR DESCRIPTION
Made a mistake in the previous blender. Calculated the f1_score between the output of union of CNN and LSTM and the blender, instead of between output of padding and blender. This seems to be the best basic for comparing the f1_score with those of CNN and LSTM. 

This blending ensemble improved LSTM's f1_score by 0.03

Find the notebook [here](https://github.com/Jolomi-Tosanwumi/stage-f-06-wine-tasting/blob/master/model/final-model-cnn-lstm.ipynb)